### PR TITLE
feat: Onboarding 및 로그인 일부 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(libs.androidx.compose.material3)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.kakao.sdk.user)
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.PickitPickit">
+            android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/example/pickitpickit/MainActivity.kt
+++ b/app/src/main/java/com/example/pickitpickit/MainActivity.kt
@@ -24,26 +24,94 @@ import com.example.pickitpickit.ui.navigation.BottomNavMenuItem
 import com.example.pickitpickit.ui.navigation.MainNavGraph
 import com.example.pickitpickit.ui.theme.PickitPickitTheme
 
+import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import com.example.pickitpickit.core.datastore.UserPreferences
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.compose.runtime.rememberCoroutineScope
+import com.example.pickitpickit.ui.login.LoginScreen
+import com.example.pickitpickit.ui.onboarding.OnboardingScreen
+
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
+        val splashScreen = installSplashScreen()
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
+        val userPreferences = UserPreferences(this)
+        var startRoute by mutableStateOf<String?>(null)
+
+        lifecycleScope.launch {
+            userPreferences.isOnboardingCompleted.collect { completed ->
+                if (startRoute == null) {
+                    // 추후 카카오 자동 로그인 여부에 따라 Login으로 갈지 Onboarding으로 갈지 판단 가능.
+                    // 현재는 온보딩 완료 여부만 판단
+                    startRoute = if (completed) "Main" else "Login"
+                }
+            }
+        }
+
+        // startRoute가 결정될 때까지 스플래시 화면을 유지
+        splashScreen.setKeepOnScreenCondition { startRoute == null }
+
         setContent {
             PickitPickitTheme {
-                MainScreen()
+                startRoute?.let { route ->
+                    val mapViewModel: MapViewModel = viewModel()
+                    RootScreen(
+                        startRoute = route,
+                        mapViewModel = mapViewModel,
+                        userPreferences = userPreferences
+                    )
+                }
             }
         }
     }
 }
 
 @Composable
-fun MainScreen() {
+fun RootScreen(startRoute: String, mapViewModel: MapViewModel, userPreferences: UserPreferences) {
+    val rootNavController = rememberNavController()
+    val coroutineScope = rememberCoroutineScope()
+
+    NavHost(navController = rootNavController, startDestination = startRoute) {
+        composable("Login") {
+            LoginScreen(
+                onLoginSuccess = {
+                    rootNavController.navigate("Onboarding") {
+                        popUpTo("Login") { inclusive = true }
+                    }
+                }
+            )
+        }
+        composable("Onboarding") {
+            OnboardingScreen(
+                onComplete = {
+                    coroutineScope.launch {
+                        userPreferences.setOnboardingCompleted(true)
+                    }
+                    rootNavController.navigate("Main") {
+                        popUpTo("Onboarding") { inclusive = true }
+                    }
+                }
+            )
+        }
+        composable("Main") {
+            MainScreen(mapViewModel = mapViewModel)
+        }
+    }
+}
+
+@Composable
+fun MainScreen(mapViewModel: MapViewModel) {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
-    
-    // Shared MapViewModel
-    val mapViewModel: MapViewModel = viewModel()
     
     // 현재 ViewModel의 카테고리 상태 (탭 하이라이트 등 연동을 위함)
     val currentCategory by mapViewModel.selectedCategory.collectAsState()
@@ -61,8 +129,6 @@ fun MainScreen() {
         bottomBar = {
             NavigationBar {
                 bottomNavItems.forEach { item ->
-                    // 선택 여부 판별: 
-                    // 마이페이지는 라우트로 판별, 홈/기타탭은 MapCategory로 판별
                     val isSelected = if (item == BottomNavMenuItem.MyPage) {
                         currentRoute == item.route
                     } else {
@@ -83,7 +149,6 @@ fun MainScreen() {
                                     restoreState = true
                                 }
                             } else {
-                                // 현재 라우트가 Home(Map)이 아니면 Home으로 한 번 이동
                                 if (currentRoute != BottomNavMenuItem.Home.route) {
                                     navController.navigate(BottomNavMenuItem.Home.route) {
                                         navController.graph.startDestinationRoute?.let { route ->
@@ -93,7 +158,6 @@ fun MainScreen() {
                                         restoreState = true
                                     }
                                 }
-                                // 지도는 유지한 채 카테고리만 변경
                                 item.mapCategory?.let { mapViewModel.setCategory(it) }
                             }
                         }
@@ -107,13 +171,5 @@ fun MainScreen() {
             mapViewModel = mapViewModel,
             modifier = Modifier.padding(innerPadding)
         )
-    }
-}
-
-@Preview(showBackground = true, showSystemUi = true)
-@Composable
-fun MainScreenPreview() {
-    PickitPickitTheme {
-        MainScreen()
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/core/datastore/UserPreferences.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/datastore/UserPreferences.kt
@@ -1,0 +1,32 @@
+package com.example.pickitpickit.core.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+// DataStore 인스턴스 생성 (Context의 확장 프로퍼티)
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "user_prefs")
+
+class UserPreferences(private val context: Context) {
+
+    // 저장할 키 정의
+    private val ONBOARDING_COMPLETED_KEY = booleanPreferencesKey("onboarding_completed")
+
+    // 온보딩 완료 상태 읽기 (Flow 반환)
+    val isOnboardingCompleted: Flow<Boolean> = context.dataStore.data
+        .map { preferences ->
+            preferences[ONBOARDING_COMPLETED_KEY] ?: false
+        }
+
+    // 온보딩 완료 상태 저장
+    suspend fun setOnboardingCompleted(completed: Boolean) {
+        context.dataStore.edit { preferences ->
+            preferences[ONBOARDING_COMPLETED_KEY] = completed
+        }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/login/LoginScreen.kt
@@ -1,0 +1,122 @@
+package com.example.pickitpickit.ui.login
+
+import android.content.Context
+import android.util.Log
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.pickitpickit.R
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
+
+@Composable
+fun LoginScreen(
+    onLoginSuccess: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val context = LocalContext.current
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .background(Color.White)
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Spacer(modifier = Modifier.weight(1f))
+
+        Image(
+            painter = painterResource(id = R.drawable.logo_pikipiki),
+            contentDescription = "앱 로고",
+            modifier = Modifier
+                .width(180.dp)
+                .height(120.dp)
+        )
+        
+        Spacer(modifier = Modifier.height(16.dp))
+        
+        Text(
+            text = "당신의 취향을 저격하는\n나만의 랜덤박스 가이드",
+            fontSize = 16.sp,
+            color = Color.Gray,
+            textAlign = androidx.compose.ui.text.style.TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        // 임시 카카오 로그인 버튼 UI (실제 이미지 리소스가 있다면 그것으로 대체 가능)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(54.dp)
+                .clip(RoundedCornerShape(12.dp))
+                .background(Color(0xFFFEE500))
+                .clickable {
+                    handleKakaoLogin(context, onLoginSuccess)
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                // 여기에 카카오 심볼 아이콘 추가 가능
+                Text(
+                    text = "카카오 로그인",
+                    color = Color.Black,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+        
+        Spacer(modifier = Modifier.height(32.dp))
+    }
+}
+
+private fun handleKakaoLogin(context: Context, onLoginSuccess: () -> Unit) {
+    val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+        if (error != null) {
+            Log.e("KAKAO_LOGIN", "카카오계정으로 로그인 실패", error)
+        } else if (token != null) {
+            Log.i("KAKAO_LOGIN", "카카오계정으로 로그인 성공 ${token.accessToken}")
+            onLoginSuccess()
+        }
+    }
+
+    // 카카오톡이 설치되어 있으면 카카오톡으로 로그인, 아니면 카카오계정으로 로그인
+    if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+        UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+            if (error != null) {
+                Log.e("KAKAO_LOGIN", "카카오톡으로 로그인 실패", error)
+
+                // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
+                // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
+                if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                    return@loginWithKakaoTalk
+                }
+
+                // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
+                UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+            } else if (token != null) {
+                Log.i("KAKAO_LOGIN", "카카오톡으로 로그인 성공 ${token.accessToken}")
+                onLoginSuccess()
+            }
+        }
+    } else {
+        UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+    }
+}


### PR DESCRIPTION
- Splash Screen API 적용 및 앱 로고 연결 완료
- DataStore 기반 온보딩 스킵 로직(UserPreferences) 구현
- 카카오 로그인 전용 화면(LoginScreen) 신규 구현
- NavGraph 분리 (Login -> Onboarding -> Main) 흐름 완성