### PR TITLE
feat: 홈 화면 지도 UI 구현 및 카카오맵 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,11 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        ndk {
+            // 카카오맵 SDK는 x86_64를 지원하지 않음 (에뮬레이터 주의)
+            abiFilters += listOf("arm64-v8a", "armeabi-v7a")
+        }
     }
 
     buildTypes {
@@ -37,6 +42,11 @@ android {
     buildFeatures {
         compose = true
     }
+    packaging {
+        jniLibs {
+            useLegacyPackaging = true
+        }
+    }
 }
 
 dependencies {
@@ -52,6 +62,8 @@ dependencies {
     implementation(libs.androidx.navigation.compose)
     implementation(libs.kakao.sdk.user)
     implementation("androidx.datastore:datastore-preferences:1.0.0")
+    implementation("com.kakao.maps.open:android:2.12.8")
+    implementation("com.google.android.gms:play-services-location:21.3.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:name=".GlobalApplication"
@@ -14,6 +16,10 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.PickitPickit">
+        <meta-data
+            android:name="com.kakao.maps.appKey"
+            android:value="4597cdb7fc04bfb5aca3e2f07d375aa7" />
+
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/app/src/main/java/com/example/pickitpickit/GlobalApplication.kt
+++ b/app/src/main/java/com/example/pickitpickit/GlobalApplication.kt
@@ -2,12 +2,16 @@ package com.example.pickitpickit
 
 import android.app.Application
 import com.kakao.sdk.common.KakaoSdk
+import com.kakao.vectormap.KakaoMapSdk
 
 class GlobalApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        
-        // 카카오 SDK 초기화
+
+        // 카카오 로그인 SDK 초기화
         KakaoSdk.init(this, "4597cdb7fc04bfb5aca3e2f07d375aa7")
+
+        // 카카오맵 SDK 초기화
+        KakaoMapSdk.init(this, "4597cdb7fc04bfb5aca3e2f07d375aa7")
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/MainActivity.kt
+++ b/app/src/main/java/com/example/pickitpickit/MainActivity.kt
@@ -51,7 +51,9 @@ class MainActivity : ComponentActivity() {
                 if (startRoute == null) {
                     // 추후 카카오 자동 로그인 여부에 따라 Login으로 갈지 Onboarding으로 갈지 판단 가능.
                     // 현재는 온보딩 완료 여부만 판단
-                    startRoute = if (completed) "Main" else "Login"
+                    // TODO: 개발 완료 후 아래 줄 원복 필요
+                    // startRoute = if (completed) "Main" else "Login"
+                    startRoute = "Main" // 임시: 메인 화면 바로 진입
                 }
             }
         }

--- a/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
@@ -1,34 +1,830 @@
 package com.example.pickitpickit.ui.home
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
+import android.view.ViewGroup
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+
+
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.example.pickitpickit.R
 import com.example.pickitpickit.ui.map.MapCategory
 import com.example.pickitpickit.ui.map.MapViewModel
+import com.google.android.gms.location.LocationServices
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.KakaoMapReadyCallback
+import com.kakao.vectormap.LatLng
+import com.kakao.vectormap.MapLifeCycleCallback
+import com.kakao.vectormap.MapView
+import com.kakao.vectormap.camera.CameraUpdateFactory
+import com.kakao.vectormap.label.LabelOptions
+import com.kakao.vectormap.label.LabelStyle
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(mapViewModel: MapViewModel) {
     val selectedCategory by mapViewModel.selectedCategory.collectAsState()
+    val isBottomSheetVisible by mapViewModel.isBottomSheetVisible.collectAsState()
+    val searchQuery by mapViewModel.searchQuery.collectAsState()
+    val recentSearches by mapViewModel.recentSearches.collectAsState()
+    val registeredTags by mapViewModel.registeredTags.collectAsState()
+    val context = LocalContext.current
 
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(text = "메인 지도 화면")
-            Text(text = "현재 필터: ${getCategoryLabel(selectedCategory)}")
+    // 카테고리 + 검색어 통합 필터링
+    val filteredStores = remember(searchQuery, selectedCategory) {
+        mapViewModel.getFilteredStores()
+    }
+
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+    var isSearchFocused by remember { mutableStateOf(false) }
+    
+    // 사용자가 입력 중인 검색어 상태 (실시간 검색 방지)
+    var inputText by remember(searchQuery) { mutableStateOf(searchQuery) }
+    val focusManager = LocalFocusManager.current
+
+    // 검색창이 열려있을 때 뒤로 가기 버튼을 누르면 포커스만 해제
+    BackHandler(enabled = isSearchFocused) {
+        focusManager.clearFocus()
+        isSearchFocused = false
+    }
+
+    // 카카오맵 인스턴스 보관
+    var kakaoMapInstance by remember { mutableStateOf<KakaoMap?>(null) }
+    var myLocationLabel by remember { mutableStateOf<com.kakao.vectormap.label.Label?>(null) }
+    val fusedLocationClient = remember { LocationServices.getFusedLocationProviderClient(context) }
+
+    // 현재 위치로 카메라 이동 + 빨간 핀 마커 표시
+    fun moveToCurrentLocation() {
+        if (android.content.pm.PackageManager.PERMISSION_GRANTED ==
+            androidx.core.content.ContextCompat.checkSelfPermission(
+                context, android.Manifest.permission.ACCESS_FINE_LOCATION
+            )
+        ) {
+            fusedLocationClient.lastLocation.addOnSuccessListener { location ->
+                location?.let {
+                    val latLng = LatLng.from(it.latitude, it.longitude)
+
+                    // 카메라 이동
+                    kakaoMapInstance?.moveCamera(
+                        CameraUpdateFactory.newCenterPosition(latLng, 15)
+                    )
+
+                    // 기존 마커 제거 후 새 마커 추가
+                    // KakaoMap은 Vector Drawable을 직접 지원하지 않으므로 Bitmap 변환 필요
+                    val markerBitmap = getBitmapFromDrawable(context, R.drawable.ic_my_location_marker)
+                    val layer = kakaoMapInstance?.labelManager?.layer
+                    myLocationLabel?.let { label -> layer?.remove(label) }
+                    myLocationLabel = layer?.addLabel(
+                        LabelOptions.from(latLng)
+                            .setStyles(LabelStyle.from(markerBitmap))
+                    )
+                }
+            }
+        }
+    }
+
+    // ── 위치 권한 요청 ─────────────────────────────────────────
+    val locationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) { permissions ->
+        val granted = permissions[android.Manifest.permission.ACCESS_FINE_LOCATION] == true
+                || permissions[android.Manifest.permission.ACCESS_COARSE_LOCATION] == true
+        if (granted) moveToCurrentLocation()
+    }
+
+    LaunchedEffect(Unit) {
+        locationPermissionLauncher.launch(
+            arrayOf(
+                android.Manifest.permission.ACCESS_FINE_LOCATION,
+                android.Manifest.permission.ACCESS_COARSE_LOCATION
+            )
+        )
+    }
+
+    // 지도 준비되면 현재 위치로 이동
+    LaunchedEffect(kakaoMapInstance) {
+        if (kakaoMapInstance != null) moveToCurrentLocation()
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+
+        // ── 1. 카카오맵 ──────────────────────────────────────
+        KakaoMapView(
+            modifier = Modifier.fillMaxSize(),
+            onMapReady = { kakaoMapInstance = it }
+        )
+
+        // ── 2. 상단 오버레이 ──────────────────────────────────
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .statusBarsPadding()
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+        ) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                // 1) 검색 영역 (투명해지지 않고 최상단 유지)
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .zIndex(2f),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    SearchBar(
+                        query = inputText,
+                        onQueryChange = { inputText = it },
+                        onSearch = { 
+                            mapViewModel.updateSearchQuery(inputText)
+                            focusManager.clearFocus()
+                        },
+                        onClearQuery = { inputText = "" },
+                        isFocused = isSearchFocused,
+                        onFocusChanged = { isSearchFocused = it },
+                        modifier = Modifier.weight(1f)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    // 검색 실행 버튼 (우측 파란 박스)
+                    Box(
+                        modifier = Modifier
+                            .size(44.dp)
+                            .clip(CircleShape)
+                            .background(Color(0xFF3B6EF8))
+                            .clickable {
+                                mapViewModel.updateSearchQuery(inputText)
+                                focusManager.clearFocus()
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_location_arrow),
+                            contentDescription = "검색",
+                            tint = Color.White,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                }
+
+                // 2) 하단 내용 (드롭다운 패널과 겹치는 Box)
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    // 원래 하단 버튼들 (드롭다운이 열리면 30% 투명해짐)
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .alpha(if (isSearchFocused) 0.3f else 1f)
+                    ) {
+                        Spacer(modifier = Modifier.height(10.dp))
+                        CategoryFilterRow(
+                            selectedCategory = selectedCategory,
+                            onCategorySelect = { mapViewModel.setCategory(it) }
+                        )
+                        Spacer(modifier = Modifier.height(10.dp))
+                        StoreCountBadge(count = filteredStores.size)
+                    }
+
+                    // 드롭다운 패널 (버튼들 위로 덮으며 나타남)
+                    androidx.compose.animation.AnimatedVisibility(
+                        visible = isSearchFocused,
+                        modifier = Modifier.zIndex(3f),
+                        enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
+                        exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut()
+                    ) {
+                        SearchDropdownPanel(
+                            recentSearches = recentSearches,
+                            registeredTags = registeredTags,
+                            onSearchSelect = { query ->
+                                mapViewModel.updateSearchQuery(query)
+                                focusManager.clearFocus()
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        // ── 3. 우측 FAB ──────────────────────────────────────
+        Column(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .padding(end = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            MapFabButton(iconRes = R.drawable.ic_compass, contentDescription = "나침반")
+            MapFabButton(
+                iconRes = R.drawable.ic_my_location,
+                contentDescription = "현재 위치",
+                onClick = { moveToCurrentLocation() }
+            )
+        }
+
+        // ── 4. 하단 내 주변 추천 버튼 ─────────────────
+        NearbyRecommendButton(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .navigationBarsPadding()
+                .padding(bottom = 16.dp),
+            onClick = { mapViewModel.showBottomSheet() }
+        )
+    }
+
+    // ── 5. Bottom Sheet ──────────────────────────────────────
+    if (isBottomSheetVisible) {
+        ModalBottomSheet(
+            onDismissRequest = { mapViewModel.hideBottomSheet() },
+            sheetState = sheetState,
+            containerColor = Color.White,
+            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+        ) {
+            NearbyStoreBottomSheet(
+                stores = filteredStores,
+                onClose = { mapViewModel.hideBottomSheet() }
+            )
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// 카카오맵 AndroidView 래핑
+// ────────────────────────────────────────────────────────────
+@Composable
+fun KakaoMapView(
+    modifier: Modifier = Modifier,
+    onMapReady: (KakaoMap) -> Unit = {}
+) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var mapViewRef: MapView? = null
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_RESUME -> mapViewRef?.resume()
+                Lifecycle.Event.ON_PAUSE  -> mapViewRef?.pause()
+                else -> {}
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    AndroidView(
+        factory = { context ->
+            MapView(context).also { mapView ->
+                mapViewRef = mapView
+                mapView.layoutParams = ViewGroup.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+                )
+                mapView.start(
+                    object : MapLifeCycleCallback() {
+                        override fun onMapDestroy() {}
+                        override fun onMapError(e: Exception) {}
+                    },
+                    object : KakaoMapReadyCallback() {
+                        override fun onMapReady(kakaoMap: KakaoMap) {
+                            onMapReady(kakaoMap)
+                        }
+                    }
+                )
+            }
+        },
+        modifier = modifier
+    )
+}
+
+// ────────────────────────────────────────────────────────────
+// 검색바 (실제 TextField 구현)
+// ────────────────────────────────────────────────────────────
+@Composable
+fun SearchBar(
+    query: String = "",
+    onQueryChange: (String) -> Unit = {},
+    onSearch: () -> Unit = {},
+    onClearQuery: () -> Unit = {},
+    isFocused: Boolean = false,
+    onFocusChanged: (Boolean) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .clip(RoundedCornerShape(if (isFocused) 16.dp else 50.dp))
+            .background(Color.White)
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.Search,
+            contentDescription = "검색",
+            tint = Color.Gray,
+            modifier = Modifier.size(20.dp)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+
+        // 실제 입력 가능한 TextField
+        BasicTextField(
+            value = query,
+            onValueChange = onQueryChange,
+            modifier = Modifier
+                .weight(1f)
+                .padding(vertical = 12.dp)
+                .onFocusChanged { state -> onFocusChanged(state.isFocused) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(onSearch = { onSearch() }),
+            textStyle = androidx.compose.ui.text.TextStyle(
+                fontSize = 15.sp,
+                color = Color.DarkGray
+            ),
+            decorationBox = { innerTextField ->
+                if (query.isEmpty()) {
+                    Text(
+                        text = "매장명, 주소, 태그 검색",
+                        color = Color.Gray,
+                        fontSize = 15.sp
+                    )
+                }
+                innerTextField()
+            }
+        )
+
+        // X 버튼 (query 있을 때만 표시)
+        if (query.isNotEmpty()) {
+            Spacer(modifier = Modifier.width(4.dp))
+            Text(
+                text = "✕",
+                color = Color.Gray,
+                fontSize = 16.sp,
+                modifier = Modifier
+                    .padding(4.dp)
+                    .clickable { onClearQuery() }
+            )
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// 검색 드롭다운 패널
+// ────────────────────────────────────────────────────────────
+@Composable
+fun SearchDropdownPanel(
+    recentSearches: List<String>,
+    registeredTags: List<String>,
+    onSearchSelect: (String) -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 8.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            // 최근 검색 Title
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Search, contentDescription = null, tint = Color(0xFF3B6EF8), modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("최근 검색", fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color.Black)
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            // 최근 검색 리스트
+            if (recentSearches.isEmpty()) {
+                Text(
+                    text = "최근 검색어가 없습니다.",
+                    fontSize = 14.sp,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(start = 28.dp, top = 8.dp)
+                )
+            } else {
+                recentSearches.forEach { search ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { onSearchSelect(search) }
+                        .padding(vertical = 8.dp, horizontal = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(Icons.Default.Search, contentDescription = null, tint = Color.Gray, modifier = Modifier.size(16.dp))
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Text(search, fontSize = 15.sp, color = Color.DarkGray)
+                }
+                } // forEach 닫기
+            } // else 닫기
+            
+            Spacer(modifier = Modifier.height(20.dp))
+            HorizontalDivider(color = Color.LightGray.copy(alpha = 0.5f), thickness = 1.dp)
+            Spacer(modifier = Modifier.height(20.dp))
+            
+            // 내가 등록한 태그 Title
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Star, contentDescription = null, tint = Color(0xFFE5A000), modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("내가 등록한 태그", fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color.Black)
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            // 태그 리스트
+            if (registeredTags.isEmpty()) {
+                Text(
+                    text = "등록한 태그가 없습니다.",
+                    fontSize = 14.sp,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(start = 28.dp, top = 8.dp)
+                )
+            } else {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    registeredTags.forEach { tag ->
+                    Row(
+                        modifier = Modifier
+                            .border(1.dp, Color(0xFFFFD700), RoundedCornerShape(8.dp))
+                            .background(Color(0xFFFFFBE6), RoundedCornerShape(8.dp))
+                            .clickable { onSearchSelect(tag) }
+                            .padding(horizontal = 10.dp, vertical = 6.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.Star, contentDescription = null, tint = Color.DarkGray, modifier = Modifier.size(14.dp))
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text(tag, fontSize = 13.sp, color = Color.DarkGray)
+                    }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// 카테고리 필터 Row
+// ────────────────────────────────────────────────────────────
+@Composable
+fun CategoryFilterRow(
+    selectedCategory: MapCategory,
+    onCategorySelect: (MapCategory) -> Unit
+) {
+    val items = listOf(
+        MapCategory.ALL to "≡ 전체",
+        MapCategory.CLAW_MACHINE to "인형뽑기",
+        MapCategory.GACHA to "가챠",
+        MapCategory.MIXED to "복합"
+    )
+
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        items.forEach { (category, label) ->
+            val isSelected = selectedCategory == category
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(50.dp))
+                    .background(if (isSelected) Color(0xFF3B6EF8) else Color.White)
+                    .clickable { onCategorySelect(category) }
+                    .padding(horizontal = 14.dp, vertical = 8.dp)
+            ) {
+                Text(
+                    text = label,
+                    color = if (isSelected) Color.White else Color.DarkGray,
+                    fontSize = 13.sp,
+                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal
+                )
+            }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// 주변 매장 수 배지
+// ────────────────────────────────────────────────────────────
+@Composable
+fun StoreCountBadge(count: Int) {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(50.dp))
+            .background(Color.White)
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(text = "📍 주변 매장 ", fontSize = 13.sp, color = Color.DarkGray)
+            Text(
+                text = "${count}개",
+                fontSize = 13.sp,
+                color = Color(0xFF3B6EF8),
+                fontWeight = FontWeight.Bold
+            )
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// 우측 FAB 버튼
+// ────────────────────────────────────────────────────────────
+@Composable
+fun MapFabButton(
+    iconRes: Int,
+    contentDescription: String,
+    onClick: () -> Unit = {}
+) {
+    Box(
+        modifier = Modifier
+            .size(44.dp)
+            .clip(CircleShape)
+            .background(Color.White)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        Icon(
+            painter = painterResource(id = iconRes),
+            contentDescription = contentDescription,
+            tint = Color.DarkGray,
+            modifier = Modifier.size(22.dp)
+        )
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// 내 주변 추천 버튼
+// ────────────────────────────────────────────────────────────
+@Composable
+fun NearbyRecommendButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
+    Box(
+        modifier = modifier
+            .clip(RoundedCornerShape(50.dp))
+            .background(Color(0xFF1A1A2E))
+            .clickable { onClick() }
+            .padding(horizontal = 32.dp, vertical = 14.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Icon(
+                imageVector = Icons.Default.Star,
+                contentDescription = null,
+                tint = Color(0xFFFFD700),
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = "내 주변 추천",
+                color = Color.White,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(text = "∨", color = Color.White, fontSize = 13.sp)
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// Bottom Sheet 내용
+// ────────────────────────────────────────────────────────────
+@Composable
+fun NearbyStoreBottomSheet(
+    stores: List<StoreItem>,
+    onClose: () -> Unit
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        // 핸들
+        Box(
+            modifier = Modifier
+                .width(40.dp)
+                .height(4.dp)
+                .clip(RoundedCornerShape(2.dp))
+                .background(Color.LightGray)
+                .align(Alignment.CenterHorizontally)
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "주변 매장 ${stores.size}개",
+            fontSize = 18.sp,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(horizontal = 20.dp)
+        )
+        Spacer(modifier = Modifier.height(12.dp))
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(max = 480.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            items(stores) { store ->
+                StoreListItem(store = store)
+            }
+            item { Spacer(modifier = Modifier.height(16.dp)) }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────
+// 매장 리스트 아이템
+// ────────────────────────────────────────────────────────────
+@Composable
+fun StoreListItem(store: StoreItem) {
+    val categoryLabel = when (store.category) {
+        MapCategory.CLAW_MACHINE -> "인형뽑기"
+        MapCategory.GACHA -> "가챠"
+        MapCategory.MIXED -> "복합"
+        MapCategory.ALL -> ""
+    }
+    val categoryColor = when (store.category) {
+        MapCategory.CLAW_MACHINE -> Color(0xFFFF9500)
+        MapCategory.GACHA -> Color(0xFF34C759)
+        MapCategory.MIXED -> Color(0xFF5856D6)
+        MapCategory.ALL -> Color.Gray
+    }
+
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(12.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 썸네일 (더미)
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0xFFEEEEEE)),
+                contentAlignment = Alignment.TopStart
+            ) {
+                // 카테고리 뱃지
+                Box(
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(categoryColor)
+                        .padding(horizontal = 4.dp, vertical = 2.dp)
+                ) {
+                    Text(text = categoryLabel, color = Color.White, fontSize = 9.sp, fontWeight = FontWeight.Bold)
+                }
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            // 매장 정보
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = store.name,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    Text(
+                        text = "${store.distanceMeters}m",
+                        fontSize = 13.sp,
+                        color = Color(0xFF3B6EF8),
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = null,
+                        tint = Color(0xFFFFD700),
+                        modifier = Modifier.size(14.dp)
+                    )
+                    Spacer(modifier = Modifier.width(3.dp))
+                    Text(text = "${store.rating}", fontSize = 12.sp, color = Color.DarkGray)
+                    Text(text = " (${store.reviewCount})", fontSize = 11.sp, color = Color.Gray)
+                }
+
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(text = "📍 ${store.address}", fontSize = 11.sp, color = Color.Gray, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                Text(text = "🕐 ${store.hours}", fontSize = 11.sp, color = Color.Gray)
+
+                Spacer(modifier = Modifier.height(6.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    store.tags.take(3).forEach { tag ->
+                        Text(
+                            text = "#$tag",
+                            fontSize = 11.sp,
+                            color = Color(0xFF3B6EF8),
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(4.dp))
+                                .background(Color(0xFFEEF3FF))
+                                .padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                }
+            }
         }
     }
 }
 
 private fun getCategoryLabel(category: MapCategory): String {
-    return when(category) {
+    return when (category) {
         MapCategory.ALL -> "전체"
         MapCategory.CLAW_MACHINE -> "인형뽑기"
         MapCategory.GACHA -> "가챠"
         MapCategory.MIXED -> "복합"
     }
+}
+
+// ────────────────────────────────────────────────────────────
+// Vector Drawable → Bitmap 변환 (KakaoMap 마커용)
+// ────────────────────────────────────────────────────────────
+fun getBitmapFromDrawable(context: android.content.Context, drawableResId: Int): android.graphics.Bitmap {
+    val drawable = androidx.core.content.ContextCompat.getDrawable(context, drawableResId)!!
+    val bitmap = android.graphics.Bitmap.createBitmap(
+        drawable.intrinsicWidth.coerceAtLeast(1),
+        drawable.intrinsicHeight.coerceAtLeast(1),
+        android.graphics.Bitmap.Config.ARGB_8888
+    )
+    val canvas = android.graphics.Canvas(bitmap)
+    drawable.setBounds(0, 0, canvas.width, canvas.height)
+    drawable.draw(canvas)
+    return bitmap
+}
+
+// ────────────────────────────────────────────────────────────
+// Previews
+// ────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true)
+@Composable
+fun SearchBarPreview() {
+    SearchBar()
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CategoryFilterRowPreview() {
+    CategoryFilterRow(
+        selectedCategory = MapCategory.ALL,
+        onCategorySelect = {}
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+fun StoreCountBadgePreview() {
+    StoreCountBadge(count = 20)
+}
+
+@Preview(showBackground = true)
+@Composable
+fun NearbyRecommendButtonPreview() {
+    NearbyRecommendButton(onClick = {})
+}
+
+@Preview(showBackground = true, widthDp = 360)
+@Composable
+fun StoreListItemPreview() {
+    StoreListItem(store = dummyStores.first())
+}
+
+@Preview(showBackground = true, widthDp = 360, heightDp = 600)
+@Composable
+fun NearbyStoreBottomSheetPreview() {
+    NearbyStoreBottomSheet(
+        stores = dummyStores,
+        onClose = {}
+    )
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/home/StoreItem.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/StoreItem.kt
@@ -1,0 +1,74 @@
+package com.example.pickitpickit.ui.home
+
+import com.example.pickitpickit.ui.map.MapCategory
+
+data class StoreItem(
+    val id: Int,
+    val name: String,
+    val category: MapCategory,
+    val rating: Float,
+    val reviewCount: Int,
+    val address: String,
+    val hours: String,
+    val tags: List<String>,
+    val distanceMeters: Int
+)
+
+// 더미 데이터 (백엔드 연동 전 UI 테스트용)
+val dummyStores = listOf(
+    StoreItem(
+        id = 1,
+        name = "캐치팡 홍대입구점",
+        category = MapCategory.CLAW_MACHINE,
+        rating = 4.5f,
+        reviewCount = 120,
+        address = "서울특별시 마포구 양화로 16",
+        hours = "10:00 - 23:00",
+        tags = listOf("포켓몬", "디즈니", "원피스", "+1"),
+        distanceMeters = 90
+    ),
+    StoreItem(
+        id = 2,
+        name = "미니돌 홍대점",
+        category = MapCategory.CLAW_MACHINE,
+        rating = 4.3f,
+        reviewCount = 90,
+        address = "서울특별시 마포구 홍익로 4",
+        hours = "11:00 - 24:00",
+        tags = listOf("산리오", "원피스", "짱구", "+1"),
+        distanceMeters = 125
+    ),
+    StoreItem(
+        id = 3,
+        name = "퍼니랜드 홍대2호점",
+        category = MapCategory.MIXED,
+        rating = 4.7f,
+        reviewCount = 150,
+        address = "서울특별시 마포구 어울마당로 7",
+        hours = "10:00 - 23:00",
+        tags = listOf("포켓몬", "귀멸의칼날"),
+        distanceMeters = 231
+    ),
+    StoreItem(
+        id = 4,
+        name = "프라이즈존 홍대AK점",
+        category = MapCategory.CLAW_MACHINE,
+        rating = 4.5f,
+        reviewCount = 120,
+        address = "서울특별시 마포구 양화로 18",
+        hours = "11:00 - 23:00",
+        tags = listOf("BT21", "카카오프렌즈"),
+        distanceMeters = 302
+    ),
+    StoreItem(
+        id = 5,
+        name = "가챠월드 홍대점",
+        category = MapCategory.GACHA,
+        rating = 4.2f,
+        reviewCount = 74,
+        address = "서울특별시 마포구 와우산로 11",
+        hours = "12:00 - 22:00",
+        tags = listOf("마블", "디즈니"),
+        distanceMeters = 410
+    )
+)

--- a/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
@@ -1,15 +1,85 @@
 package com.example.pickitpickit.ui.map
 
 import androidx.lifecycle.ViewModel
+import com.example.pickitpickit.ui.home.StoreItem
+import com.example.pickitpickit.ui.home.dummyStores
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 
 class MapViewModel : ViewModel() {
+
+    // 카테고리 필터 상태
     private val _selectedCategory = MutableStateFlow(MapCategory.ALL)
     val selectedCategory: StateFlow<MapCategory> = _selectedCategory.asStateFlow()
 
+    // 검색어 상태
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery: StateFlow<String> = _searchQuery.asStateFlow()
+
+    // 내 주변 추천 Bottom Sheet 표시 여부
+    private val _isBottomSheetVisible = MutableStateFlow(false)
+    val isBottomSheetVisible: StateFlow<Boolean> = _isBottomSheetVisible.asStateFlow()
+
+    // 전체 매장 리스트 (추후 API로 교체)
+    private val _nearbyStores = MutableStateFlow<List<StoreItem>>(dummyStores)
+    val nearbyStores: StateFlow<List<StoreItem>> = _nearbyStores.asStateFlow()
+
+    // 추후 API 연동 시 사용할 최근 검색어 / 등록 태그 상태 (현재는 더미 데이터)
+    private val _recentSearches = MutableStateFlow<List<String>>(listOf("포켓몬", "피카츄", "패트와 매트"))
+    val recentSearches: StateFlow<List<String>> = _recentSearches.asStateFlow()
+
+    private val _registeredTags = MutableStateFlow<List<String>>(listOf("#원피스", "#포켓몬", "#디즈니"))
+    val registeredTags: StateFlow<List<String>> = _registeredTags.asStateFlow()
+
     fun setCategory(category: MapCategory) {
         _selectedCategory.value = category
+    }
+
+    fun updateSearchQuery(query: String) {
+        _searchQuery.value = query
+        // 검색어가 있으면 자동으로 결과 시트 표시
+        _isBottomSheetVisible.value = query.isNotEmpty()
+        
+        // 유효한 검색어일 경우 최근 검색어 목록에 추가
+        if (query.isNotBlank()) {
+            addRecentSearch(query)
+        }
+    }
+
+    private fun addRecentSearch(query: String) {
+        val currentList = _recentSearches.value.toMutableList()
+        currentList.remove(query) // 중복 검색어 제거 후 최상단 배치
+        currentList.add(0, query)
+        // 최대 10개까지만 유지
+        _recentSearches.value = currentList.take(10)
+    }
+
+    fun clearSearch() {
+        _searchQuery.value = ""
+    }
+
+    fun showBottomSheet() {
+        _isBottomSheetVisible.value = true
+    }
+
+    fun hideBottomSheet() {
+        _isBottomSheetVisible.value = false
+    }
+
+    // 카테고리 + 검색어를 함께 적용한 필터링 결과
+    fun getFilteredStores(): List<StoreItem> {
+        val query = _searchQuery.value.trim()
+        val category = _selectedCategory.value
+
+        return _nearbyStores.value.filter { store ->
+            val matchCategory = category == MapCategory.ALL || store.category == category
+            val matchQuery = query.isEmpty() ||
+                    store.name.contains(query, ignoreCase = true) ||
+                    store.address.contains(query, ignoreCase = true) ||
+                    store.tags.any { it.contains(query, ignoreCase = true) }
+            matchCategory && matchQuery
+        }
     }
 }

--- a/app/src/main/res/drawable/ic_compass.xml
+++ b/app/src/main/res/drawable/ic_compass.xml
@@ -1,0 +1,20 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2z"
+        android:strokeWidth="1.5"
+        android:strokeColor="#333333"/>
+    <path
+        android:fillColor="#FF3B30"
+        android:pathData="M12,4 L14,12 L12,11 L10,12 Z"/>
+    <path
+        android:fillColor="#999999"
+        android:pathData="M12,20 L10,12 L12,13 L14,12 Z"/>
+    <path
+        android:fillColor="#333333"
+        android:pathData="M12,11 m-1,0 a1,1 0 1,0 2,0 a1,1 0 1,0 -2,0"/>
+</vector>

--- a/app/src/main/res/drawable/ic_location_arrow.xml
+++ b/app/src/main/res/drawable/ic_location_arrow.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M2,12 L22,2 L12,22 L10,14 Z"/>
+</vector>
+

--- a/app/src/main/res/drawable/ic_my_location.xml
+++ b/app/src/main/res/drawable/ic_my_location.xml
@@ -1,0 +1,31 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/transparent"
+        android:pathData="M12,8C9.79,8 8,9.79 8,12s1.79,4 4,4 4,-1.79 4,-4S14.21,8 12,8z"
+        android:strokeWidth="2"
+        android:strokeColor="#333333"/>
+    <path
+        android:fillColor="#333333"
+        android:pathData="M12,2 L12,4"/>
+    <path
+        android:fillColor="#333333"
+        android:pathData="M12,20 L12,22"/>
+    <path
+        android:fillColor="#333333"
+        android:pathData="M2,12 L4,12"/>
+    <path
+        android:fillColor="#333333"
+        android:pathData="M20,12 L22,12"/>
+    <path
+        android:strokeWidth="2"
+        android:strokeColor="#333333"
+        android:fillColor="@android:color/transparent"
+        android:pathData="M12,2 L12,4 M12,20 L12,22 M2,12 L4,12 M20,12 L22,12"/>
+    <path
+        android:fillColor="#3B6EF8"
+        android:pathData="M12,6 C8.69,6 6,8.69 6,12 C6,15.31 8.69,18 12,18 C15.31,18 18,15.31 18,12 C18,8.69 15.31,6 12,6 Z M12,16 C9.79,16 8,14.21 8,12 C8,9.79 9.79,8 12,8 C14.21,8 16,9.79 16,12 C16,14.21 14.21,16 12,16 Z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_my_location_marker.xml
+++ b/app/src/main/res/drawable/ic_my_location_marker.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="18dp"
+    android:height="23dp"
+    android:viewportWidth="32"
+    android:viewportHeight="40">
+    <!-- 핀 몸통 -->
+    <path
+        android:fillColor="#FF3B30"
+        android:pathData="M16,0 C9.37,0 4,5.37 4,12 C4,20 16,40 16,40 C16,40 28,20 28,12 C28,5.37 22.63,0 16,0 Z"/>
+    <!-- 핀 중심 흰 원 -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16,16 m-5,0 a5,5 0 1,0 10,0 a5,5 0 1,0 -10,0"/>
+</vector>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,10 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        // 카카오 로그인 SDK
         maven { url = uri("https://devrepo.kakao.com/nexus/content/groups/public/") }
+        // 카카오맵 SDK (별도 레포 필요)
+        maven { url = uri("https://devrepo.kakao.com/nexus/repository/kakaomap-releases/") }
     }
 }
 


### PR DESCRIPTION
## ✅ 이슈 요구사항 완료 내역
- 카카오맵 연동: SDK 의존성 추가, Manifest 앱키 등록, AndroidView로 MapView 임베드 및 라이프사이클 연결 완료
- 위치 기능: 현재 위치 권한(Fine/Coarse) 요청 및 승인 시 초기 카메라 이동 로직 구현
 
**홈 화면 UI**
- 상단 검색바 UI 및 카테고리 필터 탭 (전체/인형뽑기/가챠/복합) 구현
- 주변 매장 개수 배지 및 우측 나침반/현재위치 FAB 버튼 추가
- '내 주변 추천' 버튼 및 클릭 시 올라오는 매장 리스트 Bottom Sheet 구현 (더미 데이터 연동)
- 로직: 백엔드 연동을 대비해 MapViewModel에 StateFlow로 상태 분리 설계 완료

## 🌟 추가로 개선한 UX/기능 (이슈 외 사항)
- 검색 실행 최적화: 한 글자 칠 때마다 즉시 검색되지 않고, 입력 완료 후 [검색] 또는 [화살표] 버튼을 눌렀을 때만 검색이 실행되도록 개선
- 검색창 UI 디테일 개선:
- 검색창의 X 버튼 클릭 시 창이 닫히지 않고 텍스트만 지워지도록 수정
- 시스템 뒤로 가기 버튼 클릭 시 앱이 꺼지지 않고 검색창 드롭다운만 닫히도록 예외 처리
- 애니메이션 및 오버레이: 검색 드롭다운 노출 시 부드러운 슬라이딩 애니메이션(slideInVertically) 추가 및 하단 버튼들을 덮으면서 투명하게(Dim) 만드는 오버레이 효과 적용
- 최근 검색어/태그 뼈대 구축: 검색 성공 시 '최근 검색어' 리스트 맨 앞으로 검색어가 추가되는 뷰모델 로직 구현

Closes #11 