### PR TITLE
feat: kakao login

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,12 @@ dependencies {
     implementation("androidx.datastore:datastore-preferences:1.0.0")
     implementation("com.kakao.maps.open:android:2.12.8")
     implementation("com.google.android.gms:play-services-location:21.3.0")
+
+    // Retrofit + OkHttp (백엔드 API 통신)
+    implementation("com.squareup.retrofit2:retrofit:2.11.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.11.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/example/pickitpickit/GlobalApplication.kt
+++ b/app/src/main/java/com/example/pickitpickit/GlobalApplication.kt
@@ -1,6 +1,9 @@
 package com.example.pickitpickit
 
 import android.app.Application
+import com.example.pickitpickit.core.datastore.UserPreferences
+import com.example.pickitpickit.core.network.AuthInterceptor
+import com.example.pickitpickit.core.network.RetrofitClient
 import com.kakao.sdk.common.KakaoSdk
 import com.kakao.vectormap.KakaoMapSdk
 
@@ -13,5 +16,10 @@ class GlobalApplication : Application() {
 
         // 카카오맵 SDK 초기화
         KakaoMapSdk.init(this, "4597cdb7fc04bfb5aca3e2f07d375aa7")
+
+        // Retrofit 클라이언트 초기화 (JWT 자동 헤더 삽입 포함)
+        val userPreferences = UserPreferences(this)
+        val authInterceptor = AuthInterceptor(userPreferences)
+        RetrofitClient.create(authInterceptor)
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/MainActivity.kt
+++ b/app/src/main/java/com/example/pickitpickit/MainActivity.kt
@@ -90,11 +90,14 @@ fun RootScreen(startRoute: String, mapViewModel: MapViewModel, userPreferences: 
     NavHost(navController = rootNavController, startDestination = startRoute) {
         composable("Login") {
             LoginScreen(
-                onLoginSuccess = {
-                    rootNavController.navigate("Onboarding") {
+                onLoginSuccess = { onboardingCompleted ->
+                    // 서버가 알려주는 온보딩 여부로 다음 화면 결정
+                    val destination = if (onboardingCompleted) "Main" else "Onboarding"
+                    rootNavController.navigate(destination) {
                         popUpTo("Login") { inclusive = true }
                     }
-                }
+                },
+                userPreferences = userPreferences
             )
         }
         composable("Onboarding") {

--- a/app/src/main/java/com/example/pickitpickit/core/datastore/UserPreferences.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/datastore/UserPreferences.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -14,19 +15,58 @@ val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "us
 
 class UserPreferences(private val context: Context) {
 
-    // 저장할 키 정의
+    // ──────────────────────────────────────────────────────────────
+    // 저장 키 정의
+    // ──────────────────────────────────────────────────────────────
+
     private val ONBOARDING_COMPLETED_KEY = booleanPreferencesKey("onboarding_completed")
 
-    // 온보딩 완료 상태 읽기 (Flow 반환)
-    val isOnboardingCompleted: Flow<Boolean> = context.dataStore.data
-        .map { preferences ->
-            preferences[ONBOARDING_COMPLETED_KEY] ?: false
-        }
+    // TODO: 백엔드 명세 확인 후 키 이름 변경 가능
+    private val ACCESS_TOKEN_KEY  = stringPreferencesKey("access_token")
+    private val REFRESH_TOKEN_KEY = stringPreferencesKey("refresh_token")
 
-    // 온보딩 완료 상태 저장
+    // ──────────────────────────────────────────────────────────────
+    // 온보딩 완료 상태
+    // ──────────────────────────────────────────────────────────────
+
+    val isOnboardingCompleted: Flow<Boolean> = context.dataStore.data
+        .map { preferences -> preferences[ONBOARDING_COMPLETED_KEY] ?: false }
+
     suspend fun setOnboardingCompleted(completed: Boolean) {
-        context.dataStore.edit { preferences ->
-            preferences[ONBOARDING_COMPLETED_KEY] = completed
+        context.dataStore.edit { it[ONBOARDING_COMPLETED_KEY] = completed }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // JWT 토큰 저장 / 읽기 / 삭제
+    // ──────────────────────────────────────────────────────────────
+
+    /** Access Token 읽기 (없으면 null) */
+    fun getAccessToken(): Flow<String?> = context.dataStore.data
+        .map { it[ACCESS_TOKEN_KEY] }
+
+    /** Refresh Token 읽기 (없으면 null) */
+    fun getRefreshToken(): Flow<String?> = context.dataStore.data
+        .map { it[REFRESH_TOKEN_KEY] }
+
+    /** 로그인 성공 시 토큰 저장 */
+    suspend fun saveTokens(accessToken: String, refreshToken: String) {
+        context.dataStore.edit {
+            it[ACCESS_TOKEN_KEY]  = accessToken
+            it[REFRESH_TOKEN_KEY] = refreshToken
         }
     }
+
+    /** 로그아웃 시 토큰 삭제 */
+    suspend fun clearTokens() {
+        context.dataStore.edit {
+            it.remove(ACCESS_TOKEN_KEY)
+            it.remove(REFRESH_TOKEN_KEY)
+        }
+    }
+
+    /** 로그아웃 시 모든 사용자 데이터 초기화 */
+    suspend fun clearAll() {
+        context.dataStore.edit { it.clear() }
+    }
 }
+

--- a/app/src/main/java/com/example/pickitpickit/core/model/AuthModels.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/model/AuthModels.kt
@@ -1,16 +1,39 @@
 package com.example.pickitpickit.core.model
 
 // ──────────────────────────────────────────────────────────────────────────────
+// 공통 API 응답 래퍼
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 모든 API 응답의 공통 래퍼
+ * { "status": 0, "success": true, "code": "...", "message": "...", "data": { ... } }
+ */
+data class ApiResponse<T>(
+    val status: Int,
+    val success: Boolean,
+    val code: String,
+    val message: String,
+    val data: T?
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
 // 요청 (Request) 모델
 // ──────────────────────────────────────────────────────────────────────────────
 
 /**
  * 카카오 로그인 요청 Body
- * TODO: 백엔드 명세 확인 후 필드명 수정 필요
- *   - accessToken 방식인지 authorizationCode 방식인지 확인
+ * POST /api/auth/kakao/login
  */
 data class KakaoLoginRequest(
-    val accessToken: String      // 카카오 SDK에서 받은 Access Token
+    val kakaoAccessToken: String   // 카카오 SDK OAuthToken.accessToken
+)
+
+/**
+ * 토큰 갱신 요청 Body
+ * TODO: 토큰 갱신 엔드포인트 명세 확인 후 수정
+ */
+data class TokenRefreshRequest(
+    val refreshToken: String
 )
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -18,36 +41,37 @@ data class KakaoLoginRequest(
 // ──────────────────────────────────────────────────────────────────────────────
 
 /**
- * 로그인/회원가입 공통 응답
- * TODO: 백엔드 명세 확인 후 필드명 수정 필요
+ * 카카오 로그인 응답 data 필드
  */
-data class AuthResponse(
-    val accessToken: String,     // 서버 발급 JWT Access Token
-    val refreshToken: String,    // 서버 발급 JWT Refresh Token
-    val isNewUser: Boolean       // true → 신규 가입 (온보딩 필요), false → 기존 유저
+data class LoginData(
+    val accessToken: String,
+    val refreshToken: String,
+    val user: UserDto
 )
 
 /**
- * 토큰 갱신 요청 Body
- * TODO: 백엔드 명세 확인 후 필드명 수정 필요
+ * 사용자 정보
  */
-data class TokenRefreshRequest(
+data class UserDto(
+    val id: Long,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val onboardingCompleted: Boolean = false  // 서버는 온보딩 완료 여부를 관리함
+)
+
+/**
+ * 토큰 재발급 응답 data 필드
+ * POST /api/auth/token/reissue
+ */
+data class TokenRefreshData(
+    val accessToken: String,
+    val refreshToken: String     // 새 refreshToken도 함께 발급됨
+)
+
+/**
+ * 로그아웃 요청 Body
+ * POST /api/auth/logout
+ */
+data class LogoutRequest(
     val refreshToken: String
-)
-
-/**
- * 토큰 갱신 응답
- * TODO: 백엔드 명세 확인 후 필드명 수정 필요
- */
-data class TokenRefreshResponse(
-    val accessToken: String
-)
-
-/**
- * API 공통 에러 응답
- * TODO: 백엔드 에러 응답 포맷 확인 후 수정 필요
- */
-data class ApiError(
-    val code: String,
-    val message: String
 )

--- a/app/src/main/java/com/example/pickitpickit/core/model/AuthModels.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/model/AuthModels.kt
@@ -1,0 +1,53 @@
+package com.example.pickitpickit.core.model
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 요청 (Request) 모델
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 카카오 로그인 요청 Body
+ * TODO: 백엔드 명세 확인 후 필드명 수정 필요
+ *   - accessToken 방식인지 authorizationCode 방식인지 확인
+ */
+data class KakaoLoginRequest(
+    val accessToken: String      // 카카오 SDK에서 받은 Access Token
+)
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 응답 (Response) 모델
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 로그인/회원가입 공통 응답
+ * TODO: 백엔드 명세 확인 후 필드명 수정 필요
+ */
+data class AuthResponse(
+    val accessToken: String,     // 서버 발급 JWT Access Token
+    val refreshToken: String,    // 서버 발급 JWT Refresh Token
+    val isNewUser: Boolean       // true → 신규 가입 (온보딩 필요), false → 기존 유저
+)
+
+/**
+ * 토큰 갱신 요청 Body
+ * TODO: 백엔드 명세 확인 후 필드명 수정 필요
+ */
+data class TokenRefreshRequest(
+    val refreshToken: String
+)
+
+/**
+ * 토큰 갱신 응답
+ * TODO: 백엔드 명세 확인 후 필드명 수정 필요
+ */
+data class TokenRefreshResponse(
+    val accessToken: String
+)
+
+/**
+ * API 공통 에러 응답
+ * TODO: 백엔드 에러 응답 포맷 확인 후 수정 필요
+ */
+data class ApiError(
+    val code: String,
+    val message: String
+)

--- a/app/src/main/java/com/example/pickitpickit/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/AuthInterceptor.kt
@@ -1,0 +1,36 @@
+package com.example.pickitpickit.core.network
+
+import com.example.pickitpickit.core.datastore.UserPreferences
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.runBlocking
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * JWT Access Token을 모든 API 요청 헤더에 자동으로 삽입하는 OkHttp Interceptor
+ *
+ * Authorization: Bearer {accessToken} 형태로 추가
+ * 토큰이 없는 경우(로그인 전)에는 헤더를 추가하지 않음
+ */
+class AuthInterceptor(
+    private val userPreferences: UserPreferences
+) : Interceptor {
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val token = runBlocking {
+            userPreferences.getAccessToken().firstOrNull()
+        }
+
+        val request = if (token.isNullOrEmpty()) {
+            // 토큰 없음 → 헤더 없이 그대로 전송 (로그인 요청 등)
+            chain.request()
+        } else {
+            // 토큰 있음 → Authorization 헤더 추가
+            chain.request().newBuilder()
+                .addHeader("Authorization", "Bearer $token")
+                .build()
+        }
+
+        return chain.proceed(request)
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/core/network/AuthRepository.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/AuthRepository.kt
@@ -1,0 +1,148 @@
+package com.example.pickitpickit.core.network
+
+import android.content.Context
+import android.util.Log
+import com.example.pickitpickit.core.datastore.UserPreferences
+import com.example.pickitpickit.core.model.LogoutRequest
+import com.example.pickitpickit.core.model.TokenRefreshRequest
+import com.example.pickitpickit.core.model.UserDto
+import com.kakao.sdk.user.UserApiClient
+import kotlinx.coroutines.flow.firstOrNull
+
+/**
+ * 인증 관련 API 호출을 담당하는 Repository
+ *
+ * - 토큰 재발급 (reissueToken)
+ * - 로그아웃     (logout) — 서버 폐기 + Kakao SDK logout
+ * - 내 정보 조회 (getMe)
+ *
+ * UI에서 직접 RetrofitClient를 쓰지 않고 이 클래스를 통해 호출
+ */
+class AuthRepository(
+    private val userPreferences: UserPreferences,
+    private val context: Context
+) {
+
+    // ──────────────────────────────────────────────────────────────
+    // 토큰 재발급
+    // POST /api/auth/token/reissue
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * Refresh Token으로 새 Access Token + Refresh Token 발급
+     * 앱 시작 시 또는 401 응답 시 자동으로 호출
+     *
+     * @return 성공 여부 (true = 토큰 갱신 완료)
+     */
+    suspend fun reissueToken(): Boolean {
+        val currentRefreshToken = userPreferences.getRefreshToken().firstOrNull()
+        if (currentRefreshToken.isNullOrEmpty()) {
+            Log.w("AUTH_REPO", "reissueToken: refreshToken 없음 → 로그인 필요")
+            return false
+        }
+
+        return try {
+            val response = RetrofitClient.authApi.reissueToken(
+                TokenRefreshRequest(refreshToken = currentRefreshToken)
+            )
+
+            if (response.isSuccessful && response.body()?.success == true) {
+                val data = response.body()!!.data!!
+                userPreferences.saveTokens(
+                    accessToken  = data.accessToken,
+                    refreshToken = data.refreshToken
+                )
+                Log.i("AUTH_REPO", "토큰 재발급 성공")
+                true
+            } else {
+                Log.e("AUTH_REPO", "토큰 재발급 실패: ${response.body()?.message}")
+                false
+            }
+        } catch (e: Exception) {
+            Log.e("AUTH_REPO", "토큰 재발급 네트워크 오류", e)
+            false
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 로그아웃
+    // POST /api/auth/logout → 성공 시 Kakao SDK logout
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 서버 로그아웃 + 카카오 SDK 로그아웃 + 로컬 토큰 삭제
+     *
+     * ⚠️ 명세: "Android에서는 이 API 성공 후 Kakao SDK logout도 함께 호출하세요"
+     *
+     * @param onComplete 로그아웃 완료 후 콜백 (성공/실패 여부 전달)
+     */
+    suspend fun logout(onComplete: (success: Boolean) -> Unit) {
+        val refreshToken = userPreferences.getRefreshToken().firstOrNull()
+        if (refreshToken.isNullOrEmpty()) {
+            Log.w("AUTH_REPO", "logout: refreshToken 없음, 로컬 데이터만 삭제")
+            clearLocalSession(onComplete)
+            return
+        }
+
+        try {
+            val response = RetrofitClient.authApi.logout(
+                LogoutRequest(refreshToken = refreshToken)
+            )
+
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("AUTH_REPO", "서버 로그아웃 성공")
+            } else {
+                Log.w("AUTH_REPO", "서버 로그아웃 실패: ${response.body()?.message} — 로컬 데이터는 삭제")
+            }
+        } catch (e: Exception) {
+            Log.e("AUTH_REPO", "서버 로그아웃 네트워크 오류 — 로컬 데이터는 삭제", e)
+        }
+
+        // 서버 결과와 무관하게 로컬 세션 삭제 + 카카오 SDK 로그아웃
+        clearLocalSession(onComplete)
+    }
+
+    /** 로컬 토큰 삭제 + 카카오 SDK 로그아웃 */
+    private suspend fun clearLocalSession(onComplete: (success: Boolean) -> Unit) {
+        userPreferences.clearTokens()
+
+        // 카카오 SDK 로그아웃 (토큰 삭제, 실패해도 무시)
+        UserApiClient.instance.logout { error ->
+            if (error != null) {
+                Log.w("AUTH_REPO", "카카오 SDK 로그아웃 실패 (무시)", error)
+            } else {
+                Log.i("AUTH_REPO", "카카오 SDK 로그아웃 완료")
+            }
+            onComplete(true)
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 내 정보 조회
+    // GET /api/auth/me  (Authorization 헤더 자동 삽입)
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 현재 로그인한 사용자 정보 조회
+     * AccessToken은 AuthInterceptor가 자동으로 헤더에 삽입
+     *
+     * @return UserDto (성공) / null (실패)
+     */
+    suspend fun getMe(): UserDto? {
+        return try {
+            val response = RetrofitClient.authApi.getMe()
+
+            if (response.isSuccessful && response.body()?.success == true) {
+                val user = response.body()!!.data
+                Log.i("AUTH_REPO", "내 정보 조회 성공: id=${user?.id}, nickname=${user?.nickname}")
+                user
+            } else {
+                Log.e("AUTH_REPO", "내 정보 조회 실패: ${response.body()?.message}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("AUTH_REPO", "내 정보 조회 네트워크 오류", e)
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
@@ -1,0 +1,64 @@
+package com.example.pickitpickit.core.network
+
+import com.example.pickitpickit.core.network.api.AuthApi
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
+
+/**
+ * Retrofit 싱글톤 클라이언트
+ *
+ * TODO: 백엔드 팀에서 서버 주소 받으면 BASE_URL 수정 필요
+ *   - 개발 서버: "http://개발서버IP:포트/"
+ *   - 운영 서버: "https://api.pickitpickit.com/"  (예시)
+ */
+object RetrofitClient {
+
+    // ──────────────────────────────────────────────────────────────
+    // TODO: 백엔드 팀에 서버 BASE_URL 확인 후 수정
+    // ──────────────────────────────────────────────────────────────
+    private const val BASE_URL = "https://api.example.com/"  // 임시 주소
+
+    /**
+     * AuthInterceptor를 주입해 클라이언트를 생성
+     * Application이 초기화된 후 GlobalApplication에서 호출
+     */
+    fun create(authInterceptor: AuthInterceptor): RetrofitClient {
+        return RetrofitClient.also {
+            it.authInterceptor = authInterceptor
+            it.initialize()
+        }
+    }
+
+    private lateinit var authInterceptor: AuthInterceptor
+    private lateinit var retrofit: Retrofit
+
+    private fun initialize() {
+        // 디버그용 로그 인터셉터 (Release 빌드에서는 NONE으로 자동 설정)
+        val loggingInterceptor = HttpLoggingInterceptor().apply {
+            level = HttpLoggingInterceptor.Level.BODY
+        }
+
+        val okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(authInterceptor)   // JWT 자동 헤더 삽입
+            .addInterceptor(loggingInterceptor) // 요청/응답 Logcat 출력
+            .connectTimeout(30, TimeUnit.SECONDS)
+            .readTimeout(30, TimeUnit.SECONDS)
+            .writeTimeout(30, TimeUnit.SECONDS)
+            .build()
+
+        retrofit = Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // API 인터페이스 접근자 (필요한 API 추가 시 여기에 추가)
+    // ──────────────────────────────────────────────────────────────
+
+    val authApi: AuthApi by lazy { retrofit.create(AuthApi::class.java) }
+}

--- a/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
@@ -16,10 +16,7 @@ import java.util.concurrent.TimeUnit
  */
 object RetrofitClient {
 
-    // ──────────────────────────────────────────────────────────────
-    // TODO: 백엔드 팀에 서버 BASE_URL 확인 후 수정
-    // ──────────────────────────────────────────────────────────────
-    private const val BASE_URL = "https://api.example.com/"  // 임시 주소
+    private const val BASE_URL = "https://pickit-pickit.site/"
 
     /**
      * AuthInterceptor를 주입해 클라이언트를 생성

--- a/app/src/main/java/com/example/pickitpickit/core/network/api/AuthApi.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/api/AuthApi.kt
@@ -1,37 +1,67 @@
 package com.example.pickitpickit.core.network.api
 
-import com.example.pickitpickit.core.model.AuthResponse
+import com.example.pickitpickit.core.model.ApiResponse
 import com.example.pickitpickit.core.model.KakaoLoginRequest
+import com.example.pickitpickit.core.model.LoginData
+import com.example.pickitpickit.core.model.LogoutRequest
+import com.example.pickitpickit.core.model.TokenRefreshData
 import com.example.pickitpickit.core.model.TokenRefreshRequest
-import com.example.pickitpickit.core.model.TokenRefreshResponse
+import com.example.pickitpickit.core.model.UserDto
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 /**
  * 인증 관련 API 인터페이스
- *
- * TODO: 백엔드 명세 확인 후 엔드포인트 경로 수정 필요
- *   - 예시로 /auth/kakao, /auth/refresh 를 써뒀음
- *   - 실제 명세에 따라 @POST 경로 및 Request/Response 필드 변경
  */
 interface AuthApi {
 
     /**
      * 카카오 Access Token → 서버 JWT 교환
-     * TODO: 실제 엔드포인트 경로 확인 후 수정
+     * POST /api/auth/kakao/login
+     *
+     * Request:  { "kakaoAccessToken": "..." }
+     * Response: { status, success, code, message, data: { accessToken, refreshToken, user } }
      */
-    @POST("auth/kakao")
+    @POST("api/auth/kakao/login")
     suspend fun loginWithKakao(
         @Body body: KakaoLoginRequest
-    ): Response<AuthResponse>
+    ): Response<ApiResponse<LoginData>>
 
     /**
-     * Refresh Token으로 Access Token 재발급
-     * TODO: 실제 엔드포인트 경로 확인 후 수정
+     * Refresh Token으로 Access Token + Refresh Token 재발급
+     * POST /api/auth/token/reissue
+     *
+     * Request:  { "refreshToken": "..." }
+     * Response: { data: { accessToken, refreshToken } }
      */
-    @POST("auth/refresh")
-    suspend fun refreshToken(
+    @POST("api/auth/token/reissue")
+    suspend fun reissueToken(
         @Body body: TokenRefreshRequest
-    ): Response<TokenRefreshResponse>
+    ): Response<ApiResponse<TokenRefreshData>>
+
+    /**
+     * 로그아웃 (Refresh Token 폐기)
+     * POST /api/auth/logout
+     *
+     * ⚠️ Android에서는 이 API 성공 후 Kakao SDK logout도 함께 호출할 것
+     * Request:  { "refreshToken": "..." }
+     * Response: { data: "string" }
+     */
+    @POST("api/auth/logout")
+    suspend fun logout(
+        @Body body: LogoutRequest
+    ): Response<ApiResponse<String>>
+
+    /**
+     * 내 정보 조회
+     * GET /api/auth/me
+     *
+     * Header: Authorization: Bearer {accessToken} (자동 삽입 - AuthInterceptor)
+     * Response: { data: { id, nickname, profileImageUrl } }
+     */
+    @GET("api/auth/me")
+    suspend fun getMe(): Response<ApiResponse<UserDto>>
 }
+

--- a/app/src/main/java/com/example/pickitpickit/core/network/api/AuthApi.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/api/AuthApi.kt
@@ -1,0 +1,37 @@
+package com.example.pickitpickit.core.network.api
+
+import com.example.pickitpickit.core.model.AuthResponse
+import com.example.pickitpickit.core.model.KakaoLoginRequest
+import com.example.pickitpickit.core.model.TokenRefreshRequest
+import com.example.pickitpickit.core.model.TokenRefreshResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.POST
+
+/**
+ * 인증 관련 API 인터페이스
+ *
+ * TODO: 백엔드 명세 확인 후 엔드포인트 경로 수정 필요
+ *   - 예시로 /auth/kakao, /auth/refresh 를 써뒀음
+ *   - 실제 명세에 따라 @POST 경로 및 Request/Response 필드 변경
+ */
+interface AuthApi {
+
+    /**
+     * 카카오 Access Token → 서버 JWT 교환
+     * TODO: 실제 엔드포인트 경로 확인 후 수정
+     */
+    @POST("auth/kakao")
+    suspend fun loginWithKakao(
+        @Body body: KakaoLoginRequest
+    ): Response<AuthResponse>
+
+    /**
+     * Refresh Token으로 Access Token 재발급
+     * TODO: 실제 엔드포인트 경로 확인 후 수정
+     */
+    @POST("auth/refresh")
+    suspend fun refreshToken(
+        @Body body: TokenRefreshRequest
+    ): Response<TokenRefreshResponse>
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/login/LoginScreen.kt
@@ -7,37 +7,64 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.pickitpickit.R
+import com.example.pickitpickit.core.datastore.UserPreferences
+import com.example.pickitpickit.ui.theme.PickitPickitTheme
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
-
-import androidx.compose.foundation.border
-import androidx.compose.material3.Icon
-import androidx.compose.ui.draw.rotate
-import androidx.compose.ui.draw.shadow
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.tooling.preview.Preview
-import com.example.pickitpickit.ui.theme.PickitPickitTheme
+import kotlinx.coroutines.launch
 
 @Composable
 fun LoginScreen(
-    onLoginSuccess: () -> Unit,
+    onLoginSuccess: (onboardingCompleted: Boolean) -> Unit,
+    userPreferences: UserPreferences,
     modifier: Modifier = Modifier
 ) {
     val context = LocalContext.current
+    val loginViewModel: LoginViewModel = viewModel(
+        factory = LoginViewModel.factory(userPreferences)
+    )
+    val loginState by loginViewModel.loginState.collectAsState()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    // 로그인 상태 처리
+    LaunchedEffect(loginState) {
+        when (val state = loginState) {
+            is LoginState.Success -> {
+                onLoginSuccess(state.onboardingCompleted)  // 서버 응답의 온보딩 여부 전달
+                loginViewModel.resetState()
+            }
+            is LoginState.Error -> {
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(state.message)
+                }
+                loginViewModel.resetState()
+            }
+            else -> Unit
+        }
+    }
 
     // 배경 그라데이션 브러쉬 (4단 선형 그라데이션)
     val backgroundBrush = Brush.verticalGradient(
@@ -49,89 +76,128 @@ fun LoginScreen(
         )
     )
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(brush = backgroundBrush)
-            .padding(horizontal = 24.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        Spacer(modifier = Modifier.weight(1f))
-
-        Image(
-            painter = painterResource(id = R.drawable.logo_pikipiki),
-            contentDescription = "앱 로고",
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp)
-                .aspectRatio(1.5f)
-        )
-        
-        Spacer(modifier = Modifier.weight(1f))
-
-        Box(
-            modifier = Modifier
-                .shadow(elevation = 16.dp, spotColor = Color(0x14000000), ambientColor = Color(0x14000000), shape = RoundedCornerShape(16.dp))
-                .shadow(elevation = 24.dp, spotColor = Color(0x24000000), ambientColor = Color(0x24000000), shape = RoundedCornerShape(16.dp))
-                .width(343.dp)
-                .height(48.dp)
-                .background(color = Color(0xFFFEE500), shape = RoundedCornerShape(16.dp))
-                .clickable { handleKakaoLogin(context, onLoginSuccess) },
-            contentAlignment = Alignment.Center
+                .fillMaxSize()
+                .background(brush = backgroundBrush)
+                .padding(horizontal = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
         ) {
-            Row(
-                modifier = Modifier.padding(start = 27.dp, top = 12.dp, end = 27.dp, bottom = 12.dp),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.Center
+            Spacer(modifier = Modifier.weight(1f))
+
+            Image(
+                painter = painterResource(id = R.drawable.logo_pikipiki),
+                contentDescription = "앱 로고",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+                    .aspectRatio(1.5f)
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            // 카카오 로그인 버튼
+            Box(
+                modifier = Modifier
+                    .shadow(
+                        elevation = 16.dp,
+                        spotColor = Color(0x14000000),
+                        ambientColor = Color(0x14000000),
+                        shape = RoundedCornerShape(16.dp)
+                    )
+                    .width(343.dp)
+                    .height(48.dp)
+                    .background(
+                        color = if (loginState is LoginState.Loading)
+                            Color(0xFFD4B800) else Color(0xFFFEE500),
+                        shape = RoundedCornerShape(16.dp)
+                    )
+                    .clickable(enabled = loginState !is LoginState.Loading) {
+                        handleKakaoLogin(context) { kakaoAccessToken ->
+                            loginViewModel.loginWithKakao(kakaoAccessToken)
+                        }
+                    },
+                contentAlignment = Alignment.Center
             ) {
-                Icon(
-                    painter = painterResource(id = R.drawable.ic_kakao),
-                    contentDescription = "카카오 아이콘",
-                    tint = Color(0xFF1A1A1A),
-                    modifier = Modifier.size(24.dp)
-                )
-                Spacer(modifier = Modifier.width(8.dp))
-                Text(
-                    text = "카카오로 빠르게 시작하기",
-                    color = Color(0xFF1A1A1A),
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.Bold
-                )
+                if (loginState is LoginState.Loading) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(24.dp),
+                        color = Color(0xFF1A1A1A),
+                        strokeWidth = 2.dp
+                    )
+                } else {
+                    Row(
+                        modifier = Modifier.padding(
+                            start = 27.dp, top = 12.dp, end = 27.dp, bottom = 12.dp
+                        ),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(id = R.drawable.ic_kakao),
+                            contentDescription = "카카오 아이콘",
+                            tint = Color(0xFF1A1A1A),
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(
+                            text = "카카오로 빠르게 시작하기",
+                            color = Color(0xFF1A1A1A),
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
             }
+
+            Spacer(modifier = Modifier.height(48.dp))
         }
-        
-        Spacer(modifier = Modifier.height(48.dp))
+
+        // 에러 스낵바
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier = Modifier.align(Alignment.BottomCenter)
+        ) { data ->
+            Snackbar(
+                snackbarData = data,
+                containerColor = Color(0xFF323232),
+                contentColor = Color.White
+            )
+        }
     }
 }
 
-private fun handleKakaoLogin(context: Context, onLoginSuccess: () -> Unit) {
+/**
+ * 카카오 로그인 처리
+ * 성공 시 kakaoAccessToken을 onTokenReceived 콜백으로 전달
+ */
+private fun handleKakaoLogin(
+    context: Context,
+    onTokenReceived: (kakaoAccessToken: String) -> Unit
+) {
     val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
         if (error != null) {
             Log.e("KAKAO_LOGIN", "카카오계정으로 로그인 실패", error)
         } else if (token != null) {
-            Log.i("KAKAO_LOGIN", "카카오계정으로 로그인 성공 ${token.accessToken}")
-            onLoginSuccess()
+            Log.i("KAKAO_LOGIN", "카카오 토큰 획득 성공 → 서버 로그인 요청")
+            onTokenReceived(token.accessToken)
         }
     }
 
-    // 카카오톡이 설치되어 있으면 카카오톡으로 로그인, 아니면 카카오계정으로 로그인
     if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
         UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
             if (error != null) {
                 Log.e("KAKAO_LOGIN", "카카오톡으로 로그인 실패", error)
-
-                // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
-                // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
                 if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
                     return@loginWithKakaoTalk
                 }
-
-                // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
+                // 카카오톡 로그인 실패 시 카카오계정으로 fallback
                 UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
             } else if (token != null) {
-                Log.i("KAKAO_LOGIN", "카카오톡으로 로그인 성공 ${token.accessToken}")
-                onLoginSuccess()
+                Log.i("KAKAO_LOGIN", "카카오톡 토큰 획득 성공 → 서버 로그인 요청")
+                onTokenReceived(token.accessToken)
             }
         }
     } else {
@@ -143,6 +209,22 @@ private fun handleKakaoLogin(context: Context, onLoginSuccess: () -> Unit) {
 @Composable
 fun LoginScreenPreview() {
     PickitPickitTheme {
-        LoginScreen(onLoginSuccess = {})
+        // Preview용 더미 UserPreferences (실제 DataStore 미사용)
+        // LoginScreen(onLoginSuccess = {}, userPreferences = ...)
+        // → Preview에서는 Context 없이 UserPreferences 생성 불가하므로 UI만 확인
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            Color(0xFFF2A85A),
+                            Color(0xFFFFD790),
+                            Color(0xFFFFF3E2),
+                            Color(0xFF6B98F8)
+                        )
+                    )
+                )
+        )
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/login/LoginViewModel.kt
@@ -1,0 +1,95 @@
+package com.example.pickitpickit.ui.login
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.pickitpickit.core.datastore.UserPreferences
+import com.example.pickitpickit.core.model.KakaoLoginRequest
+import com.example.pickitpickit.core.network.RetrofitClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+// ──────────────────────────────────────────────────────────────
+// 로그인 상태
+// ──────────────────────────────────────────────────────────────
+
+sealed class LoginState {
+    object Idle    : LoginState()
+    object Loading : LoginState()
+    data class Success(val onboardingCompleted: Boolean) : LoginState()  // 서버가 알려주는 온보딩 완료 여부
+    data class Error(val message: String) : LoginState()
+}
+
+// ──────────────────────────────────────────────────────────────
+// ViewModel
+// ──────────────────────────────────────────────────────────────
+
+class LoginViewModel(
+    private val userPreferences: UserPreferences
+) : ViewModel() {
+
+    private val _loginState = MutableStateFlow<LoginState>(LoginState.Idle)
+    val loginState: StateFlow<LoginState> = _loginState
+
+    /**
+     * 카카오 SDK에서 받은 accessToken을 서버에 전달하고 JWT를 발급받아 저장
+     *
+     * 흐름: 카카오 SDK → kakaoAccessToken → POST /api/auth/kakao/login → JWT 저장
+     */
+    fun loginWithKakao(kakaoAccessToken: String) {
+        viewModelScope.launch {
+            _loginState.value = LoginState.Loading
+
+            try {
+                val response = RetrofitClient.authApi.loginWithKakao(
+                    KakaoLoginRequest(kakaoAccessToken = kakaoAccessToken)
+                )
+
+                if (response.isSuccessful && response.body()?.success == true) {
+                    val data = response.body()!!.data!!
+
+                    // JWT 토큰 DataStore에 저장
+                    userPreferences.saveTokens(
+                        accessToken  = data.accessToken,
+                        refreshToken = data.refreshToken
+                    )
+
+                    Log.i("LOGIN", "서버 로그인 성공 | userId=${data.user.id}, nickname=${data.user.nickname}")
+                    // 서버가 알려주는 온보딩 완료 여부를 그대로 전달
+                    _loginState.value = LoginState.Success(data.user.onboardingCompleted)
+
+                } else {
+                    val errorMsg = response.body()?.message ?: "로그인에 실패했습니다."
+                    Log.e("LOGIN", "서버 로그인 실패: $errorMsg (HTTP ${response.code()})")
+                    _loginState.value = LoginState.Error(errorMsg)
+                }
+
+            } catch (e: Exception) {
+                Log.e("LOGIN", "네트워크 오류", e)
+                _loginState.value = LoginState.Error("네트워크 오류가 발생했습니다.\n잠시 후 다시 시도해주세요.")
+            }
+        }
+    }
+
+    /** 에러 상태 초기화 (재시도 등에 사용) */
+    fun resetState() {
+        _loginState.value = LoginState.Idle
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Factory (UserPreferences 주입용)
+    // ──────────────────────────────────────────────────────────────
+
+    companion object {
+        fun factory(userPreferences: UserPreferences): ViewModelProvider.Factory {
+            return object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return LoginViewModel(userPreferences) as T
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 변경 사항
### 백엔드 연동 (실제 API 명세 반영)
- RetrofitClient: BASE_URL = https://pickit-pickit.site/ 적용
- AuthModels: 실제 응답 구조에 맞게 전면 수정
  - KakaoLoginRequest.accessToken → kakaoAccessToken
  - ApiResponse<T> 공통 래퍼 추가
  - LoginData, UserDto, TokenRefreshData, LogoutRequest 정의
  - UserDto에 onboardingCompleted 필드 추가 (서버 관리)
### 로그인 흐름 완성
- AuthApi: 실제 엔드포인트 적용
  - POST /api/auth/kakao/login
  - POST /api/auth/token/reissue
  - POST /api/auth/logout
  - GET /api/auth/me
- LoginViewModel: 카카오 토큰 → 서버 JWT 교환 + DataStore 저장
- LoginScreen: 로딩 스피너, 에러 스낵바, 성공 시 화면 이동 처리
### 라우팅 개선
- 로그인 성공 시 서버의 onboardingCompleted 값으로 화면 분기
  - false → 온보딩 화면 (신규 유저)
  - true → 메인 화면 (기존 유저 재로그인)
### 인증 Repository
- AuthRepository: reissueToken / logout / getMe 메서드 구현
  - logout: 서버 폐기 → Kakao SDK logout → 로컬 토큰 삭제 순서 보장