### PR TITLE
feat: 검색 로그 삭제 API 연동 및 UI 이벤트 연결

### DIFF
--- a/app/src/main/java/com/example/pickitpickit/GlobalApplication.kt
+++ b/app/src/main/java/com/example/pickitpickit/GlobalApplication.kt
@@ -8,8 +8,17 @@ import com.kakao.sdk.common.KakaoSdk
 import com.kakao.vectormap.KakaoMapSdk
 
 class GlobalApplication : Application() {
+    companion object {
+        lateinit var instance: GlobalApplication
+            private set
+
+        lateinit var userPreferences: UserPreferences
+            private set
+    }
+
     override fun onCreate() {
         super.onCreate()
+        instance = this
 
         // 카카오 로그인 SDK 초기화
         KakaoSdk.init(this, "4597cdb7fc04bfb5aca3e2f07d375aa7")
@@ -18,7 +27,7 @@ class GlobalApplication : Application() {
         KakaoMapSdk.init(this, "4597cdb7fc04bfb5aca3e2f07d375aa7")
 
         // Retrofit 클라이언트 초기화 (JWT 자동 헤더 삽입 포함)
-        val userPreferences = UserPreferences(this)
+        userPreferences = UserPreferences(this)
         val authInterceptor = AuthInterceptor(userPreferences)
         RetrofitClient.create(authInterceptor)
     }

--- a/app/src/main/java/com/example/pickitpickit/core/datastore/UserPreferences.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/datastore/UserPreferences.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.Flow
@@ -24,6 +25,7 @@ class UserPreferences(private val context: Context) {
     // TODO: 백엔드 명세 확인 후 키 이름 변경 가능
     private val ACCESS_TOKEN_KEY  = stringPreferencesKey("access_token")
     private val REFRESH_TOKEN_KEY = stringPreferencesKey("refresh_token")
+    private val USER_ID_KEY       = longPreferencesKey("user_id")
 
     // ──────────────────────────────────────────────────────────────
     // 온보딩 완료 상태
@@ -42,25 +44,33 @@ class UserPreferences(private val context: Context) {
 
     /** Access Token 읽기 (없으면 null) */
     fun getAccessToken(): Flow<String?> = context.dataStore.data
-        .map { it[ACCESS_TOKEN_KEY] }
+         .map { it[ACCESS_TOKEN_KEY] }
 
     /** Refresh Token 읽기 (없으면 null) */
     fun getRefreshToken(): Flow<String?> = context.dataStore.data
-        .map { it[REFRESH_TOKEN_KEY] }
+         .map { it[REFRESH_TOKEN_KEY] }
 
-    /** 로그인 성공 시 토큰 저장 */
-    suspend fun saveTokens(accessToken: String, refreshToken: String) {
-        context.dataStore.edit {
-            it[ACCESS_TOKEN_KEY]  = accessToken
-            it[REFRESH_TOKEN_KEY] = refreshToken
+    /** User ID 읽기 (없으면 null) */
+    fun getUserId(): Flow<Long?> = context.dataStore.data
+         .map { it[USER_ID_KEY] }
+
+    /** 로그인 성공 시 토큰 저장 및 userId 저장 */
+    suspend fun saveTokens(accessToken: String, refreshToken: String, userId: Long? = null) {
+        context.dataStore.edit { prefs ->
+            prefs[ACCESS_TOKEN_KEY]  = accessToken
+            prefs[REFRESH_TOKEN_KEY] = refreshToken
+            if (userId != null) {
+                prefs[USER_ID_KEY] = userId
+            }
         }
     }
 
-    /** 로그아웃 시 토큰 삭제 */
+    /** 로그아웃 시 토큰 및 유저 정보 삭제 */
     suspend fun clearTokens() {
-        context.dataStore.edit {
-            it.remove(ACCESS_TOKEN_KEY)
-            it.remove(REFRESH_TOKEN_KEY)
+        context.dataStore.edit { prefs ->
+            prefs.remove(ACCESS_TOKEN_KEY)
+            prefs.remove(REFRESH_TOKEN_KEY)
+            prefs.remove(USER_ID_KEY)
         }
     }
 

--- a/app/src/main/java/com/example/pickitpickit/core/model/SearchModels.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/model/SearchModels.kt
@@ -1,0 +1,50 @@
+package com.example.pickitpickit.core.model
+
+// ──────────────────────────────────────────────────────────────────────────────
+// 검색 로그 API 모델
+// ──────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 검색 대상 타입
+ */
+enum class TargetType {
+    STORE  // 현재는 STORE만 사용
+}
+
+/**
+ * 검색 로그 저장 요청 Body
+ * POST /api/search-logs
+ */
+data class SaveSearchLogRequest(
+    val userId: Long,
+    val keyword: String,
+    val targetType: String = TargetType.STORE.name
+)
+
+/**
+ * 최근 검색어 항목
+ * GET /api/search-logs/recent 응답의 data 배열 아이템
+ */
+data class SearchLogDto(
+    val keyword: String,
+    val targetType: String,     // "STORE" 등
+    val searchedAt: String      // ISO 8601 (e.g. "2026-05-26T06:42:32.451Z")
+)
+
+/**
+ * 최근 검색어 개별 삭제 요청 Body
+ * DELETE /api/search-logs/recent
+ */
+data class DeleteSearchLogRequest(
+    val userId: Long,
+    val keyword: String,
+    val targetType: String = TargetType.STORE.name
+)
+
+/**
+ * 최근 검색어 전체 삭제 요청 Body
+ * DELETE /api/search-logs/recent/all
+ */
+data class DeleteAllSearchLogsRequest(
+    val userId: Long
+)

--- a/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
@@ -1,6 +1,7 @@
 package com.example.pickitpickit.core.network
 
 import com.example.pickitpickit.core.network.api.AuthApi
+import com.example.pickitpickit.core.network.api.SearchApi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -57,5 +58,6 @@ object RetrofitClient {
     // API 인터페이스 접근자 (필요한 API 추가 시 여기에 추가)
     // ──────────────────────────────────────────────────────────────
 
-    val authApi: AuthApi by lazy { retrofit.create(AuthApi::class.java) }
+    val authApi: AuthApi   by lazy { retrofit.create(AuthApi::class.java) }
+    val searchApi: SearchApi by lazy { retrofit.create(SearchApi::class.java) }
 }

--- a/app/src/main/java/com/example/pickitpickit/core/network/SearchRepository.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/SearchRepository.kt
@@ -1,0 +1,159 @@
+package com.example.pickitpickit.core.network
+
+import android.util.Log
+import com.example.pickitpickit.core.model.DeleteAllSearchLogsRequest
+import com.example.pickitpickit.core.model.DeleteSearchLogRequest
+import com.example.pickitpickit.core.model.SaveSearchLogRequest
+import com.example.pickitpickit.core.model.SearchLogDto
+import com.example.pickitpickit.core.model.TargetType
+
+/**
+ * 검색 로그 관련 API 호출을 담당하는 Repository
+ *
+ * - 검색 실행 시 로그 저장  (saveSearchLog)
+ * - 최근 검색어 조회        (getRecentSearchLogs)
+ * - 최근 검색어 개별 삭제   (deleteSearchLog)
+ * - 최근 검색어 전체 삭제   (deleteAllSearchLogs)
+ */
+class SearchRepository {
+
+    // ──────────────────────────────────────────────────────────────
+    // 검색 로그 저장
+    // POST /api/search-logs
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 검색 실행 시 서버에 로그 저장
+     *
+     * @param userId     현재 로그인한 유저 ID
+     * @param keyword    검색어
+     * @param targetType 검색 대상 타입 (기본값 STORE)
+     * @return 성공 여부
+     */
+    suspend fun saveSearchLog(
+        userId: Long,
+        keyword: String,
+        targetType: TargetType = TargetType.STORE
+    ): Boolean {
+        return try {
+            val response = RetrofitClient.searchApi.saveSearchLog(
+                SaveSearchLogRequest(
+                    userId = userId,
+                    keyword = keyword,
+                    targetType = targetType.name
+                )
+            )
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("SEARCH_REPO", "검색 로그 저장 성공: $keyword")
+                true
+            } else {
+                Log.w("SEARCH_REPO", "검색 로그 저장 실패: ${response.body()?.message}")
+                false
+            }
+        } catch (e: Exception) {
+            Log.e("SEARCH_REPO", "검색 로그 저장 네트워크 오류", e)
+            false
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 최근 검색어 조회
+    // GET /api/search-logs/recent?userId={}&limit={}
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 최근 검색어 목록 조회 (최신순, 중복 제거)
+     *
+     * @param userId 현재 로그인한 유저 ID
+     * @param limit  조회 개수 (1~20, 기본값 10)
+     * @return 검색 로그 리스트 (실패 시 빈 리스트)
+     */
+    suspend fun getRecentSearchLogs(
+        userId: Long,
+        limit: Int = 10
+    ): List<SearchLogDto> {
+        return try {
+            val response = RetrofitClient.searchApi.getRecentSearchLogs(
+                userId = userId,
+                limit = limit
+            )
+            if (response.isSuccessful && response.body()?.success == true) {
+                val logs = response.body()!!.data ?: emptyList()
+                Log.i("SEARCH_REPO", "최근 검색어 조회 성공: ${logs.size}건")
+                logs
+            } else {
+                Log.w("SEARCH_REPO", "최근 검색어 조회 실패: ${response.body()?.message}")
+                emptyList()
+            }
+        } catch (e: Exception) {
+            Log.e("SEARCH_REPO", "최근 검색어 조회 네트워크 오류", e)
+            emptyList()
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 최근 검색어 개별 삭제
+    // DELETE /api/search-logs/recent
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 특정 키워드 검색 로그 삭제
+     *
+     * @param userId     현재 로그인한 유저 ID
+     * @param keyword    삭제할 검색어
+     * @param targetType 검색 대상 타입 (기본값 STORE)
+     * @return 성공 여부
+     */
+    suspend fun deleteSearchLog(
+        userId: Long,
+        keyword: String,
+        targetType: TargetType = TargetType.STORE
+    ): Boolean {
+        return try {
+            val response = RetrofitClient.searchApi.deleteSearchLog(
+                userId = userId,
+                keyword = keyword,
+                targetType = targetType.name
+            )
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("SEARCH_REPO", "검색 로그 개별 삭제 성공: $keyword")
+                true
+            } else {
+                Log.w("SEARCH_REPO", "검색 로그 개별 삭제 실패: ${response.body()?.message}")
+                false
+            }
+        } catch (e: Exception) {
+            Log.e("SEARCH_REPO", "검색 로그 개별 삭제 네트워크 오류", e)
+            false
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // 최근 검색어 전체 삭제
+    // DELETE /api/search-logs/recent/all
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 해당 유저의 검색 로그 전부 삭제
+     *
+     * @param userId 현재 로그인한 유저 ID
+     * @return 성공 여부
+     */
+    suspend fun deleteAllSearchLogs(userId: Long): Boolean {
+        return try {
+            val response = RetrofitClient.searchApi.deleteAllSearchLogs(
+                userId = userId
+            )
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("SEARCH_REPO", "검색 로그 전체 삭제 성공")
+                true
+            } else {
+                Log.w("SEARCH_REPO", "검색 로그 전체 삭제 실패: ${response.body()?.message}")
+                false
+            }
+        } catch (e: Exception) {
+            Log.e("SEARCH_REPO", "검색 로그 전체 삭제 네트워크 오류", e)
+            false
+        }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/core/network/api/SearchApi.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/api/SearchApi.kt
@@ -1,0 +1,69 @@
+package com.example.pickitpickit.core.network.api
+
+import com.example.pickitpickit.core.model.ApiResponse
+import com.example.pickitpickit.core.model.DeleteAllSearchLogsRequest
+import com.example.pickitpickit.core.model.DeleteSearchLogRequest
+import com.example.pickitpickit.core.model.SaveSearchLogRequest
+import com.example.pickitpickit.core.model.SearchLogDto
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.HTTP
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface SearchApi {
+
+    /**
+     * 검색 로그 저장
+     * POST /api/search-logs
+     *
+     * 검색 실행 시 호출 → 서버에 키워드 기록
+     * Request: { userId, keyword, targetType }
+     */
+    @POST("api/search-logs")
+    suspend fun saveSearchLog(
+        @Body body: SaveSearchLogRequest
+    ): Response<ApiResponse<String>>
+
+    /**
+     * 최근 검색어 조회
+     * GET /api/search-logs/recent?userId={}&limit={}
+     *
+     * 같은 검색어+대상 조합은 가장 최근 1건만 노출
+     * @param userId 사용자 ID (필수)
+     * @param limit  조회 개수 1~20, 기본값 10
+     */
+    @GET("api/search-logs/recent")
+    suspend fun getRecentSearchLogs(
+        @Query("userId") userId: Long,
+        @Query("limit") limit: Int = 10
+    ): Response<ApiResponse<List<SearchLogDto>>>
+
+    /**
+     * 최근 검색어 개별 삭제
+     * DELETE /api/search-logs/recent
+     *
+     * 특정 키워드+타입 조합 삭제
+     * Request: Query parameters (userId, keyword, targetType)
+     */
+    @DELETE("api/search-logs/recent")
+    suspend fun deleteSearchLog(
+        @Query("userId") userId: Long,
+        @Query("keyword") keyword: String,
+        @Query("targetType") targetType: String
+    ): Response<ApiResponse<String>>
+
+    /**
+     * 최근 검색어 전체 삭제
+     * DELETE /api/search-logs/recent/all
+     *
+     * 해당 유저의 검색 로그 전부 삭제
+     * Request: Query parameters (userId)
+     */
+    @DELETE("api/search-logs/recent/all")
+    suspend fun deleteAllSearchLogs(
+        @Query("userId") userId: Long
+    ): Response<ApiResponse<String>>
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
@@ -233,6 +233,12 @@ fun HomeScreen(mapViewModel: MapViewModel) {
                             onSearchSelect = { query ->
                                 mapViewModel.updateSearchQuery(query)
                                 focusManager.clearFocus()
+                            },
+                            onDeleteRecentSearch = { keyword ->
+                                mapViewModel.deleteRecentSearch(keyword)
+                            },
+                            onClearAllRecentSearches = {
+                                mapViewModel.clearAllRecentSearches()
                             }
                         )
                     }
@@ -406,7 +412,9 @@ fun SearchBar(
 fun SearchDropdownPanel(
     recentSearches: List<String>,
     registeredTags: List<String>,
-    onSearchSelect: (String) -> Unit
+    onSearchSelect: (String) -> Unit,
+    onDeleteRecentSearch: (String) -> Unit,
+    onClearAllRecentSearches: () -> Unit
 ) {
     Card(
         modifier = Modifier
@@ -417,11 +425,27 @@ fun SearchDropdownPanel(
         elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            // 최근 검색 Title
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Icon(Icons.Default.Search, contentDescription = null, tint = Color(0xFF3B6EF8), modifier = Modifier.size(18.dp))
-                Spacer(modifier = Modifier.width(8.dp))
-                Text("최근 검색", fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color.Black)
+            // 최근 검색 Title 및 전체 삭제 버튼
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.Search, contentDescription = null, tint = Color(0xFF3B6EF8), modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text("최근 검색", fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color.Black)
+                }
+                if (recentSearches.isNotEmpty()) {
+                    Text(
+                        text = "전체 삭제",
+                        fontSize = 12.sp,
+                        color = Color.Gray,
+                        modifier = Modifier
+                            .clickable { onClearAllRecentSearches() }
+                            .padding(4.dp)
+                    )
+                }
             }
             Spacer(modifier = Modifier.height(12.dp))
             // 최근 검색 리스트
@@ -434,17 +458,34 @@ fun SearchDropdownPanel(
                 )
             } else {
                 recentSearches.forEach { search ->
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable { onSearchSelect(search) }
-                        .padding(vertical = 8.dp, horizontal = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Icon(Icons.Default.Search, contentDescription = null, tint = Color.Gray, modifier = Modifier.size(16.dp))
-                    Spacer(modifier = Modifier.width(12.dp))
-                    Text(search, fontSize = 15.sp, color = Color.DarkGray)
-                }
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = 4.dp, horizontal = 4.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .weight(1f)
+                                .clickable { onSearchSelect(search) }
+                                .padding(vertical = 4.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Icon(Icons.Default.Search, contentDescription = null, tint = Color.Gray, modifier = Modifier.size(16.dp))
+                            Spacer(modifier = Modifier.width(12.dp))
+                            Text(search, fontSize = 15.sp, color = Color.DarkGray)
+                        }
+                        // 개별 삭제 버튼 (✕)
+                        Text(
+                            text = "✕",
+                            color = Color.Gray,
+                            fontSize = 14.sp,
+                            modifier = Modifier
+                                .clickable { onDeleteRecentSearch(search) }
+                                .padding(8.dp)
+                        )
+                    }
                 } // forEach 닫기
             } // else 닫기
             

--- a/app/src/main/java/com/example/pickitpickit/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/login/LoginViewModel.kt
@@ -50,10 +50,11 @@ class LoginViewModel(
                 if (response.isSuccessful && response.body()?.success == true) {
                     val data = response.body()!!.data!!
 
-                    // JWT 토큰 DataStore에 저장
+                    // JWT 토큰 및 userId DataStore에 저장
                     userPreferences.saveTokens(
                         accessToken  = data.accessToken,
-                        refreshToken = data.refreshToken
+                        refreshToken = data.refreshToken,
+                        userId       = data.user.id
                     )
 
                     Log.i("LOGIN", "서버 로그인 성공 | userId=${data.user.id}, nickname=${data.user.nickname}")

--- a/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
@@ -1,14 +1,23 @@
 package com.example.pickitpickit.ui.map
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.pickitpickit.GlobalApplication
+import com.example.pickitpickit.core.network.SearchRepository
 import com.example.pickitpickit.ui.home.StoreItem
 import com.example.pickitpickit.ui.home.dummyStores
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
 
 class MapViewModel : ViewModel() {
+
+    private val searchRepository = SearchRepository()
+    private val userPreferences = GlobalApplication.userPreferences
 
     // 카테고리 필터 상태
     private val _selectedCategory = MutableStateFlow(MapCategory.ALL)
@@ -26,12 +35,32 @@ class MapViewModel : ViewModel() {
     private val _nearbyStores = MutableStateFlow<List<StoreItem>>(dummyStores)
     val nearbyStores: StateFlow<List<StoreItem>> = _nearbyStores.asStateFlow()
 
-    // 추후 API 연동 시 사용할 최근 검색어 / 등록 태그 상태 (현재는 더미 데이터)
-    private val _recentSearches = MutableStateFlow<List<String>>(listOf("포켓몬", "피카츄", "패트와 매트"))
+    // 최근 검색어 상태 (서버 연동)
+    private val _recentSearches = MutableStateFlow<List<String>>(emptyList())
     val recentSearches: StateFlow<List<String>> = _recentSearches.asStateFlow()
 
     private val _registeredTags = MutableStateFlow<List<String>>(listOf("#원피스", "#포켓몬", "#디즈니"))
     val registeredTags: StateFlow<List<String>> = _registeredTags.asStateFlow()
+
+    init {
+        // 뷰모델 생성 시 서버에서 최근 검색어 불러오기
+        loadRecentSearches()
+    }
+
+    /**
+     * 서버에서 최근 검색어를 가져옴
+     */
+    fun loadRecentSearches() {
+        viewModelScope.launch {
+            val userId = userPreferences.getUserId().firstOrNull()
+            if (userId != null) {
+                val logs = searchRepository.getRecentSearchLogs(userId)
+                _recentSearches.value = logs.map { it.keyword }
+            } else {
+                Log.w("MAP_VIEWMODEL", "loadRecentSearches: 로그인한 userId가 없음")
+            }
+        }
+    }
 
     fun setCategory(category: MapCategory) {
         _selectedCategory.value = category
@@ -42,18 +71,57 @@ class MapViewModel : ViewModel() {
         // 검색어가 있으면 자동으로 결과 시트 표시
         _isBottomSheetVisible.value = query.isNotEmpty()
         
-        // 유효한 검색어일 경우 최근 검색어 목록에 추가
         if (query.isNotBlank()) {
-            addRecentSearch(query)
+            saveSearchLog(query)
         }
     }
 
-    private fun addRecentSearch(query: String) {
-        val currentList = _recentSearches.value.toMutableList()
-        currentList.remove(query) // 중복 검색어 제거 후 최상단 배치
-        currentList.add(0, query)
-        // 최대 10개까지만 유지
-        _recentSearches.value = currentList.take(10)
+    /**
+     * 검색어 입력 시 서버에 검색 로그 저장
+     */
+    private fun saveSearchLog(query: String) {
+        viewModelScope.launch {
+            val userId = userPreferences.getUserId().firstOrNull()
+            if (userId != null) {
+                val success = searchRepository.saveSearchLog(userId, query)
+                if (success) {
+                    // 저장 성공 시 최근 검색어 새로고침
+                    loadRecentSearches()
+                }
+            }
+        }
+    }
+
+    /**
+     * 최근 검색어 개별 삭제
+     */
+    fun deleteRecentSearch(keyword: String) {
+        viewModelScope.launch {
+            val userId = userPreferences.getUserId().firstOrNull()
+            if (userId != null) {
+                val success = searchRepository.deleteSearchLog(userId, keyword)
+                if (success) {
+                    // 삭제 성공 시 리스트 갱신
+                    loadRecentSearches()
+                }
+            }
+        }
+    }
+
+    /**
+     * 최근 검색어 전체 삭제
+     */
+    fun clearAllRecentSearches() {
+        viewModelScope.launch {
+            val userId = userPreferences.getUserId().firstOrNull()
+            if (userId != null) {
+                val success = searchRepository.deleteAllSearchLogs(userId)
+                if (success) {
+                    // 전체 삭제 성공 시 빈 리스트로 갱신
+                    _recentSearches.value = emptyList()
+                }
+            }
+        }
     }
 
     fun clearSearch() {


### PR DESCRIPTION
## 🛠️ 주요 작업 내용
- DataStore ID 저장: 로그인 성공 시 사용자 고유 userId를 로컬에 영구 캐싱하여 검색 로그 조회 시 식별자로 활용
- API 스펙 연동 & 500 에러 해결: 최근 검색어 개별/전체 삭제 API 요청 시, 백엔드 OpenAPI 명세에 맞추어 바디(@Body) 형태에서 쿼리 파라미터(@Query) 방식으로 갱신하여 통신 오류 해결
- UI & 뷰모델 연결: 최근 검색어 드롭다운 패널에 '✕ 개별 삭제' 및 '전체 삭제' 버튼 UI를 배치하고 MapViewModel API 비동기 호출 이벤트와 연결하여 동적 상태 갱신 제공

Closes #15 