### PR TITLE
feat: 마이페이지 및 프로필 수정 복구, 실지간 지도 핀 마커 연동

### DIFF
--- a/app/src/main/java/com/example/pickitpickit/core/datastore/UserPreferences.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/datastore/UserPreferences.kt
@@ -5,6 +5,7 @@ import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
@@ -21,6 +22,8 @@ class UserPreferences(private val context: Context) {
     // ──────────────────────────────────────────────────────────────
 
     private val ONBOARDING_COMPLETED_KEY = booleanPreferencesKey("onboarding_completed")
+    private val PUSH_NOTIFICATIONS_ENABLED_KEY = booleanPreferencesKey("push_notifications_enabled")
+    private val SEARCH_RADIUS_KEY = intPreferencesKey("search_radius")
 
     // TODO: 백엔드 명세 확인 후 키 이름 변경 가능
     private val ACCESS_TOKEN_KEY  = stringPreferencesKey("access_token")
@@ -28,7 +31,7 @@ class UserPreferences(private val context: Context) {
     private val USER_ID_KEY       = longPreferencesKey("user_id")
 
     // ──────────────────────────────────────────────────────────────
-    // 온보딩 완료 상태
+    // 온보딩 및 설정 상태
     // ──────────────────────────────────────────────────────────────
 
     val isOnboardingCompleted: Flow<Boolean> = context.dataStore.data
@@ -36,6 +39,24 @@ class UserPreferences(private val context: Context) {
 
     suspend fun setOnboardingCompleted(completed: Boolean) {
         context.dataStore.edit { it[ONBOARDING_COMPLETED_KEY] = completed }
+    }
+
+    /** 로컬 푸시 알림 설정 여부 (기본값 true) */
+    val isPushNotificationsEnabled: Flow<Boolean> = context.dataStore.data
+        .map { preferences -> preferences[PUSH_NOTIFICATIONS_ENABLED_KEY] ?: true }
+
+    /** 로컬 푸시 알림 설정 값 변경 */
+    suspend fun setPushNotificationsEnabled(enabled: Boolean) {
+        context.dataStore.edit { it[PUSH_NOTIFICATIONS_ENABLED_KEY] = enabled }
+    }
+
+    /** 로컬 검색 반경 설정 (단위: 미터, 기본값 1000m = 1km) */
+    val searchRadius: Flow<Int> = context.dataStore.data
+        .map { preferences -> preferences[SEARCH_RADIUS_KEY] ?: 1000 }
+
+    /** 로컬 검색 반경 설정 변경 */
+    suspend fun setSearchRadius(radius: Int) {
+        context.dataStore.edit { it[SEARCH_RADIUS_KEY] = radius }
     }
 
     // ──────────────────────────────────────────────────────────────

--- a/app/src/main/java/com/example/pickitpickit/core/model/StoreModels.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/model/StoreModels.kt
@@ -1,0 +1,85 @@
+package com.example.pickitpickit.core.model
+
+/**
+ * 매장 타입
+ */
+enum class StoreType {
+    CLAW,
+    GACHA,
+    ALL
+}
+
+/**
+ * 주변 매장 개별 정보 DTO
+ * GET /api/stores/nearby 응답의 data 배열 아이템
+ */
+data class StoreNearbyResponse(
+    val id: Int,
+    val sourcePlaceId: String?,
+    val name: String,
+    val type: String,               // "CLAW", "GACHA"
+    val latitude: Double,
+    val longitude: Double,
+    val distance: Int,              // 미터 단위 거리
+    val address: String?,
+    val contact: String?,
+    val businessHours: String?,
+    val mainImageUrl: String?,
+    val kakaoDetailUrl: String?
+)
+
+/**
+ * 태그 정보 DTO
+ */
+data class TagDto(
+    val tagId: Long,
+    val name: String
+)
+
+/**
+ * 매장 등록 상품 DTO
+ */
+data class ProductDto(
+    val productId: Long,
+    val itemId: Long,
+    val itemName: String,
+    val category: String?,
+    val price: Int,
+    val inventoryMode: String?,
+    val stockQuantity: Int,
+    val stockStatus: String?,
+    val difficulty: Int,
+    val difficultyLabel: String?,
+    val imageUrl: String?,
+    val tags: List<TagDto>
+)
+
+/**
+ * 매장 기본 상세 정보 DTO
+ */
+data class StoreDetailDto(
+    val id: Long,
+    val sourcePlaceId: String?,
+    val name: String,
+    val type: String,
+    val latitude: Double,
+    val longitude: Double,
+    val distance: Int,
+    val address: String?,
+    val contact: String?,
+    val businessHours: String?,
+    val mainImageUrl: String?,
+    val kakaoDetailUrl: String?
+)
+
+/**
+ * 매장 상세 조회 API 응답 data 필드 DTO
+ * GET /api/stores/{storeId}
+ */
+data class StoreDetailResponse(
+    val store: StoreDetailDto,
+    val productCount: Int,
+    val totalStockQuantity: Int,
+    val tags: List<TagDto>,
+    val products: List<ProductDto>
+)

--- a/app/src/main/java/com/example/pickitpickit/core/network/AuthInterceptor.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/AuthInterceptor.kt
@@ -7,13 +7,16 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.Interceptor
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
+import org.json.JSONObject
 
 /**
- * JWT Access Token을 모든 API 요청 헤더에 자동으로 삽입하는 OkHttp Interceptor
- *
- * Authorization: Bearer {accessToken} 형태로 추가
- * 토큰이 없는 경우(로그인 전)에는 헤더를 추가하지 않음
+ * JWT Access Token을 모든 API 요청 헤더에 자동으로 삽입하고,
+ * 401 만료 에러 발생 시 동기식으로 토큰을 자동 재발급하여 재시도 처리하는 OkHttp Interceptor
  */
 class AuthInterceptor(
     private val userPreferences: UserPreferences
@@ -21,7 +24,6 @@ class AuthInterceptor(
 
     override fun intercept(chain: Interceptor.Chain): Response {
         // 🌟 Dispatchers.IO 컨텍스트를 명시 지정하여 OkHttp와 DataStore 간의 스레드 교착 상태(Deadlock) 원천 차단!
-        // 🌟 2초 타임아웃 보호막(withTimeoutOrNull)을 두어 혹시 모를 대기 지연 시의 앱 먹통 가능성까지 이중 방어!
         val token = runBlocking(Dispatchers.IO) {
             try {
                 withTimeoutOrNull(2000) {
@@ -33,16 +35,132 @@ class AuthInterceptor(
             }
         }
 
-        Log.d("AUTH_INTERCEPTOR", "API 요청 가로챔 | 주입할 AccessToken 존재 여부 = ${!token.isNullOrEmpty()}")
+        val request = chain.request()
+        val requestBuilder = request.newBuilder()
 
-        val request = if (token.isNullOrEmpty()) {
-            chain.request()
-        } else {
-            chain.request().newBuilder()
-                .addHeader("Authorization", "Bearer $token")
-                .build()
+        if (!token.isNullOrEmpty()) {
+            requestBuilder.addHeader("Authorization", "Bearer $token")
         }
 
-        return chain.proceed(request)
+        val response = chain.proceed(requestBuilder.build())
+
+        // 401 Unauthorized인 경우 토큰 재발급 자동 시도
+        if (response.code == 401) {
+            val urlPath = request.url.encodedPath
+            // 무한 루프 방지: 로그인/재발급/로그아웃 관련 요청은 재발급 대상에서 제외
+            if (!urlPath.contains("/api/auth/token/reissue") && 
+                !urlPath.contains("/api/auth/kakao/login") && 
+                !urlPath.contains("/api/auth/logout")
+            ) {
+                synchronized(this) {
+                    // 재발급 시도 전, 다른 스레드에서 이미 토큰이 갱신되었는지 최신 토큰 확인
+                    val currentToken = runBlocking(Dispatchers.IO) {
+                        try {
+                            withTimeoutOrNull(1000) {
+                                userPreferences.getAccessToken().first()
+                            }
+                        } catch (e: Exception) {
+                            null
+                        }
+                    }
+
+                    if (!currentToken.isNullOrEmpty() && currentToken != token) {
+                        // 다른 스레드에서 이미 토큰이 갱신된 경우, 새 토큰으로 바로 재시도
+                        response.close()
+                        val newRequest = request.newBuilder()
+                            .header("Authorization", "Bearer $currentToken")
+                            .build()
+                        return chain.proceed(newRequest)
+                    }
+
+                    // 토큰 재발급 진행을 위해 Refresh Token 획득
+                    val refreshToken = runBlocking(Dispatchers.IO) {
+                        try {
+                            withTimeoutOrNull(1000) {
+                                userPreferences.getRefreshToken().first()
+                            }
+                        } catch (e: Exception) {
+                            null
+                        }
+                    }
+
+                    if (!refreshToken.isNullOrEmpty()) {
+                        Log.w("AUTH_INTERCEPTOR", "토큰 만료 감지 (HTTP 401) -> 토큰 동기식 재발급 시도 시작 🔄")
+                        val isReissueSuccess = reissueTokenSynchronously(refreshToken)
+                        if (isReissueSuccess) {
+                            val nextToken = runBlocking(Dispatchers.IO) {
+                                try {
+                                    withTimeoutOrNull(1000) {
+                                        userPreferences.getAccessToken().first()
+                                    }
+                                } catch (e: Exception) {
+                                    null
+                                }
+                            }
+                            if (!nextToken.isNullOrEmpty()) {
+                                Log.i("AUTH_INTERCEPTOR", "토큰 재발급 성공! 새로운 AccessToken으로 원래 요청 재시도 진행 🚀")
+                                response.close()
+                                val newRequest = request.newBuilder()
+                                    .header("Authorization", "Bearer $nextToken")
+                                    .build()
+                                return chain.proceed(newRequest)
+                            }
+                        } else {
+                            Log.e("AUTH_INTERCEPTOR", "토큰 재발급 실패 -> 만료된 세션 처리 필요")
+                        }
+                    }
+                }
+            }
+        }
+
+        return response
+    }
+
+    /**
+     * 동기식으로 토큰 재발급 요청 진행 (순수 OkHttpClient를 사용하여 인터셉터 루프 방지)
+     */
+    private fun reissueTokenSynchronously(refreshToken: String): Boolean {
+        try {
+            val cleanClient = OkHttpClient.Builder()
+                .connectTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+                .readTimeout(15, java.util.concurrent.TimeUnit.SECONDS)
+                .build()
+
+            val jsonBody = JSONObject().apply {
+                put("refreshToken", refreshToken)
+            }.toString()
+
+            val mediaType = "application/json; charset=utf-8".toMediaType()
+            val reissueRequest = Request.Builder()
+                .url(RetrofitClient.BASE_URL.removeSuffix("/") + "/api/auth/token/reissue")
+                .post(jsonBody.toRequestBody(mediaType))
+                .build()
+
+            val response = cleanClient.newCall(reissueRequest).execute()
+            if (response.isSuccessful) {
+                val responseBodyStr = response.body?.string()
+                if (!responseBodyStr.isNullOrEmpty()) {
+                    val rootJson = JSONObject(responseBodyStr)
+                    if (rootJson.optBoolean("success", false)) {
+                        val dataJson = rootJson.optJSONObject("data")
+                        if (dataJson != null) {
+                            val newAccessToken = dataJson.optString("accessToken")
+                            val newRefreshToken = dataJson.optString("refreshToken")
+                            if (!newAccessToken.isNullOrEmpty() && !newRefreshToken.isNullOrEmpty()) {
+                                runBlocking(Dispatchers.IO) {
+                                    userPreferences.saveTokens(newAccessToken, newRefreshToken)
+                                }
+                                Log.i("AUTH_INTERCEPTOR", "동기식 토큰 재발급 및 로컬 DataStore 저장 완료 완료 🏆")
+                                return true
+                            }
+                        }
+                    }
+                }
+            }
+            Log.e("AUTH_INTERCEPTOR", "동기식 토큰 재발급 실패 | HTTP ${response.code}")
+        } catch (e: Exception) {
+            Log.e("AUTH_INTERCEPTOR", "동기식 토큰 재발급 중 예외 발생", e)
+        }
+        return false
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
@@ -3,6 +3,7 @@ package com.example.pickitpickit.core.network
 import com.example.pickitpickit.core.network.api.AuthApi
 import com.example.pickitpickit.core.network.api.SearchApi
 import com.example.pickitpickit.core.network.api.OnboardingApi
+import com.example.pickitpickit.core.network.api.StoreApi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -62,4 +63,5 @@ object RetrofitClient {
     val authApi: AuthApi   by lazy { retrofit.create(AuthApi::class.java) }
     val searchApi: SearchApi by lazy { retrofit.create(SearchApi::class.java) }
     val onboardingApi: OnboardingApi by lazy { retrofit.create(OnboardingApi::class.java) }
+    val storeApi: StoreApi by lazy { retrofit.create(StoreApi::class.java) }
 }

--- a/app/src/main/java/com/example/pickitpickit/core/network/StoreRepository.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/StoreRepository.kt
@@ -1,0 +1,172 @@
+package com.example.pickitpickit.core.network
+
+import android.util.Log
+import com.example.pickitpickit.ui.home.StoreItem
+import com.example.pickitpickit.ui.map.MapCategory
+
+class StoreRepository {
+
+    /**
+     * 내 주변 추천 매장 조회
+     *
+     * @param lat    사용자 위도
+     * @param lng    사용자 경도
+     * @param radius 탐색 반경(m)
+     * @param type   매장 종류 ("ALL", "CLAW", "GACHA")
+     * @return UI에 노출할 StoreItem 리스트 (실패 시 빈 리스트)
+     */
+    suspend fun getNearbyStores(
+        lat: Double,
+        lng: Double,
+        radius: Int,
+        type: String = "ALL"
+    ): List<StoreItem> {
+        return try {
+            val response = RetrofitClient.storeApi.getNearbyStores(
+                lat = lat,
+                lng = lng,
+                radius = radius,
+                type = type
+            )
+            if (response.isSuccessful && response.body()?.success == true) {
+                val dtoList = response.body()!!.data ?: emptyList()
+                Log.i("STORE_REPO", "주변 매장 조회 성공: ${dtoList.size}건 수신 (radius: ${radius}m)")
+                
+                dtoList.map { dto ->
+                    // DTO에서 StoreItem으로 매핑
+                    val mappedCategory = when (dto.type.uppercase()) {
+                        "CLAW" -> MapCategory.CLAW_MACHINE
+                        "GACHA" -> MapCategory.GACHA
+                        else -> MapCategory.MIXED
+                    }
+
+                    // 기본 태그 구성 (매장 타입에 부합하도록)
+                    val defaultTags = when (dto.type.uppercase()) {
+                        "CLAW" -> listOf("인형뽑기", "크레인게임")
+                        "GACHA" -> listOf("가챠", "캡슐토이", "피규어")
+                        else -> listOf("인형뽑기", "가챠", "종합샵")
+                    }
+
+                    StoreItem(
+                        id = dto.id,
+                        name = dto.name,
+                        category = mappedCategory,
+                        rating = 4.5f, // API에 평점 정보 부재하므로 기본값
+                        reviewCount = 10, // API에 리뷰 개수 정보 부재하므로 기본값
+                        address = dto.address ?: "주소 정보 없음",
+                        hours = dto.businessHours ?: "영업시간 정보 없음",
+                        tags = defaultTags,
+                        distanceMeters = dto.distance,
+                        latitude = dto.latitude,
+                        longitude = dto.longitude
+                    )
+                }
+            } else {
+                Log.w("STORE_REPO", "주변 매장 조회 실패: ${response.body()?.message}")
+                emptyList()
+            }
+        } catch (e: Exception) {
+            Log.e("STORE_REPO", "주변 매장 조회 네트워크 오류", e)
+            emptyList()
+        }
+    }
+
+    /**
+     * 매장 상세 조회 (등록된 상품/재고/태그 목록 포함)
+     *
+     * @param storeId 매장 ID
+     * @param lat     사용자 위도 (선택)
+     * @param lng     사용자 경도 (선택)
+     * @return 매장 상세 정보 응답 DTO (실패 시 null)
+     */
+    suspend fun getStoreDetail(
+        storeId: Long,
+        lat: Double? = null,
+        lng: Double? = null
+    ): com.example.pickitpickit.core.model.StoreDetailResponse? {
+        return try {
+            val response = RetrofitClient.storeApi.getStoreDetail(
+                storeId = storeId,
+                lat = lat,
+                lng = lng
+            )
+            if (response.isSuccessful && response.body()?.success == true) {
+                val detail = response.body()!!.data
+                Log.i("STORE_REPO", "매장 상세 조회 성공: ${detail?.store?.name ?: ""} (ID: $storeId)")
+                detail
+            } else {
+                Log.w("STORE_REPO", "매장 상세 조회 실패: ${response.body()?.message}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("STORE_REPO", "매장 상세 조회 네트워크 오류 (ID: $storeId)", e)
+            null
+        }
+    }
+
+    /**
+     * 매장 검색 (매장명 또는 주소 기준)
+     *
+     * @param keyword 검색어 (필수)
+     * @param type    매장 유형 ("ALL", "CLAW", "GACHA")
+     * @param lat     사용자 위도 (선택)
+     * @param lng     사용자 경도 (선택)
+     * @param limit   제한 개수 (1~50)
+     * @return 검색된 StoreItem 리스트 (실패 시 빈 리스트)
+     */
+    suspend fun searchStores(
+        keyword: String,
+        type: String = "ALL",
+        lat: Double? = null,
+        lng: Double? = null,
+        limit: Int = 20
+    ): List<StoreItem> {
+        return try {
+            val response = RetrofitClient.storeApi.searchStores(
+                keyword = keyword,
+                type = type,
+                lat = lat,
+                lng = lng,
+                limit = limit
+            )
+            if (response.isSuccessful && response.body()?.success == true) {
+                val dtoList = response.body()!!.data ?: emptyList()
+                Log.i("STORE_REPO", "매장 검색 성공: ${dtoList.size}건 수신 (keyword: $keyword)")
+
+                dtoList.map { dto ->
+                    val mappedCategory = when (dto.type.uppercase()) {
+                        "CLAW" -> MapCategory.CLAW_MACHINE
+                        "GACHA" -> MapCategory.GACHA
+                        else -> MapCategory.MIXED
+                    }
+
+                    val defaultTags = when (dto.type.uppercase()) {
+                        "CLAW" -> listOf("인형뽑기", "크레인게임")
+                        "GACHA" -> listOf("가챠", "캡슐토이", "피규어")
+                        else -> listOf("인형뽑기", "가챠", "종합샵")
+                    }
+
+                    StoreItem(
+                        id = dto.id,
+                        name = dto.name,
+                        category = mappedCategory,
+                        rating = 4.5f,
+                        reviewCount = 10,
+                        address = dto.address ?: "주소 정보 없음",
+                        hours = dto.businessHours ?: "영업시간 정보 없음",
+                        tags = defaultTags,
+                        distanceMeters = dto.distance,
+                        latitude = dto.latitude,
+                        longitude = dto.longitude
+                    )
+                }
+            } else {
+                Log.w("STORE_REPO", "매장 검색 실패: ${response.body()?.message}")
+                emptyList()
+            }
+        } catch (e: Exception) {
+            Log.e("STORE_REPO", "매장 검색 네트워크 오류 (keyword: $keyword)", e)
+            emptyList()
+        }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/core/network/api/StoreApi.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/api/StoreApi.kt
@@ -1,0 +1,63 @@
+package com.example.pickitpickit.core.network.api
+
+import com.example.pickitpickit.core.model.ApiResponse
+import com.example.pickitpickit.core.model.StoreDetailResponse
+import com.example.pickitpickit.core.model.StoreNearbyResponse
+import retrofit2.Response
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface StoreApi {
+
+    /**
+     * 현재 위치 기반 주변 매장 조회
+     * GET /api/stores/nearby
+     *
+     * @param lat    사용자 위도 (필수)
+     * @param lng    사용자 경도 (필수)
+     * @param radius 검색 반경(m) - 허용값: 500, 1000, 3000, 5000 (기본값: 1000)
+     * @param type   매장 유형 - 허용값: CLAW, GACHA, ALL (기본값: ALL)
+     */
+    @GET("api/stores/nearby")
+    suspend fun getNearbyStores(
+        @Query("lat") lat: Double,
+        @Query("lng") lng: Double,
+        @Query("radius") radius: Int,
+        @Query("type") type: String = "ALL"
+    ): Response<ApiResponse<List<StoreNearbyResponse>>>
+
+    /**
+     * 매장 상세 정보 및 등록된 상품/재고/태그 조회
+     * GET /api/stores/{storeId}
+     *
+     * @param storeId 매장 ID (필수)
+     * @param lat     사용자 위도 (선택)
+     * @param lng     사용자 경도 (선택)
+     */
+    @GET("api/stores/{storeId}")
+    suspend fun getStoreDetail(
+        @Path("storeId") storeId: Long,
+        @Query("lat") lat: Double? = null,
+        @Query("lng") lng: Double? = null
+    ): Response<ApiResponse<StoreDetailResponse>>
+
+    /**
+     * 매장명 또는 주소 기준 매장 검색
+     * GET /api/stores/search
+     *
+     * @param keyword 검색어 (필수)
+     * @param type    매장 유형 - CLAW, GACHA, ALL (기본값: ALL)
+     * @param lat     사용자 위도 (선택)
+     * @param lng     사용자 경도 (선택)
+     * @param limit   조회 개수 1~50 (기본값: 20)
+     */
+    @GET("api/stores/search")
+    suspend fun searchStores(
+        @Query("keyword") keyword: String,
+        @Query("type") type: String = "ALL",
+        @Query("lat") lat: Double? = null,
+        @Query("lng") lng: Double? = null,
+        @Query("limit") limit: Int = 20
+    ): Response<ApiResponse<List<StoreNearbyResponse>>>
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
@@ -104,6 +104,9 @@ fun HomeScreen(mapViewModel: MapViewModel) {
                 location?.let {
                     val latLng = LatLng.from(it.latitude, it.longitude)
 
+                    // 주변 매장 API 호출 (현재 위치 & 로컬 저장소 검색반경 자동 매핑)
+                    mapViewModel.loadNearbyStores(it.latitude, it.longitude)
+
                     // 카메라 이동
                     kakaoMapInstance?.moveCamera(
                         CameraUpdateFactory.newCenterPosition(latLng, 15)
@@ -144,6 +147,32 @@ fun HomeScreen(mapViewModel: MapViewModel) {
     // 지도 준비되면 현재 위치로 이동
     LaunchedEffect(kakaoMapInstance) {
         if (kakaoMapInstance != null) moveToCurrentLocation()
+    }
+
+    // 매장 마커들을 보관할 리스트
+    val storeLabels = remember { mutableStateListOf<com.kakao.vectormap.label.Label>() }
+
+    // 매장 목록(filteredStores)이 갱신될 때마다 마커를 지우고 새로 그림
+    LaunchedEffect(filteredStores, kakaoMapInstance) {
+        val map = kakaoMapInstance ?: return@LaunchedEffect
+        val layer = map.labelManager?.layer ?: return@LaunchedEffect
+
+        // 1. 기존 매장 마커 전부 제거
+        storeLabels.forEach { label -> layer.remove(label) }
+        storeLabels.clear()
+
+        // 2. 새 매장 마커 추가
+        val markerBitmap = getBitmapFromDrawable(context, R.drawable.ic_store_marker)
+        filteredStores.forEach { store ->
+            val storeLatLng = LatLng.from(store.latitude, store.longitude)
+            val label = layer.addLabel(
+                LabelOptions.from(storeLatLng)
+                    .setStyles(LabelStyle.from(markerBitmap))
+            )
+            if (label != null) {
+                storeLabels.add(label)
+            }
+        }
     }
 
     Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/example/pickitpickit/ui/home/StoreItem.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/StoreItem.kt
@@ -11,10 +11,12 @@ data class StoreItem(
     val address: String,
     val hours: String,
     val tags: List<String>,
-    val distanceMeters: Int
+    val distanceMeters: Int,
+    val latitude: Double,
+    val longitude: Double
 )
 
-// 더미 데이터 (백엔드 연동 전 UI 테스트용)
+// 더미 데이터 (백엔드 연동 전 UI 테스트용 및 미리보기 프리뷰용)
 val dummyStores = listOf(
     StoreItem(
         id = 1,
@@ -25,7 +27,9 @@ val dummyStores = listOf(
         address = "서울특별시 마포구 양화로 16",
         hours = "10:00 - 23:00",
         tags = listOf("포켓몬", "디즈니", "원피스", "+1"),
-        distanceMeters = 90
+        distanceMeters = 90,
+        latitude = 37.5565,
+        longitude = 126.9235
     ),
     StoreItem(
         id = 2,
@@ -36,7 +40,9 @@ val dummyStores = listOf(
         address = "서울특별시 마포구 홍익로 4",
         hours = "11:00 - 24:00",
         tags = listOf("산리오", "원피스", "짱구", "+1"),
-        distanceMeters = 125
+        distanceMeters = 125,
+        latitude = 37.5570,
+        longitude = 126.9240
     ),
     StoreItem(
         id = 3,
@@ -47,7 +53,9 @@ val dummyStores = listOf(
         address = "서울특별시 마포구 어울마당로 7",
         hours = "10:00 - 23:00",
         tags = listOf("포켓몬", "귀멸의칼날"),
-        distanceMeters = 231
+        distanceMeters = 231,
+        latitude = 37.5560,
+        longitude = 126.9228
     ),
     StoreItem(
         id = 4,
@@ -58,7 +66,9 @@ val dummyStores = listOf(
         address = "서울특별시 마포구 양화로 18",
         hours = "11:00 - 23:00",
         tags = listOf("BT21", "카카오프렌즈"),
-        distanceMeters = 302
+        distanceMeters = 302,
+        latitude = 37.5580,
+        longitude = 126.9250
     ),
     StoreItem(
         id = 5,
@@ -69,6 +79,8 @@ val dummyStores = listOf(
         address = "서울특별시 마포구 와우산로 11",
         hours = "12:00 - 22:00",
         tags = listOf("마블", "디즈니"),
-        distanceMeters = 410
+        distanceMeters = 410,
+        latitude = 37.5550,
+        longitude = 126.9215
     )
 )

--- a/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
@@ -17,7 +17,12 @@ import kotlinx.coroutines.launch
 class MapViewModel : ViewModel() {
 
     private val searchRepository = SearchRepository()
+    private val storeRepository = com.example.pickitpickit.core.network.StoreRepository()
     private val userPreferences = GlobalApplication.userPreferences
+
+    // 사용자 현재 위치 캐싱 (검색 시 정렬 옵션 결합을 위해 보관)
+    private var currentLatitude: Double? = null
+    private var currentLongitude: Double? = null
 
     // 카테고리 필터 상태
     private val _selectedCategory = MutableStateFlow(MapCategory.ALL)
@@ -31,7 +36,7 @@ class MapViewModel : ViewModel() {
     private val _isBottomSheetVisible = MutableStateFlow(false)
     val isBottomSheetVisible: StateFlow<Boolean> = _isBottomSheetVisible.asStateFlow()
 
-    // 전체 매장 리스트 (추후 API로 교체)
+    // 전체 매장 리스트 (초기값은 dummy이나 API 연동 후 실시간 반영)
     private val _nearbyStores = MutableStateFlow<List<StoreItem>>(dummyStores)
     val nearbyStores: StateFlow<List<StoreItem>> = _nearbyStores.asStateFlow()
 
@@ -45,6 +50,27 @@ class MapViewModel : ViewModel() {
     init {
         // 뷰모델 생성 시 서버에서 최근 검색어 불러오기
         loadRecentSearches()
+    }
+
+    /**
+     * 현재 위치 기반 주변 매장 로드
+     */
+    fun loadNearbyStores(latitude: Double, longitude: Double, type: String = "ALL") {
+        currentLatitude = latitude
+        currentLongitude = longitude
+        viewModelScope.launch {
+            // DataStore의 검색 반경 설정을 불러옴
+            val radius = userPreferences.searchRadius.firstOrNull() ?: 1000
+            Log.i("MAP_VIEWMODEL", "loadNearbyStores API 호출 요청: lat=$latitude, lng=$longitude, radius=$radius, type=$type")
+            
+            val stores = storeRepository.getNearbyStores(
+                lat = latitude,
+                lng = longitude,
+                radius = radius,
+                type = type
+            )
+            _nearbyStores.value = stores
+        }
     }
 
     /**
@@ -73,6 +99,23 @@ class MapViewModel : ViewModel() {
         
         if (query.isNotBlank()) {
             saveSearchLog(query)
+            searchStores(query)
+        }
+    }
+
+    /**
+     * 매장 검색 실행
+     */
+    fun searchStores(keyword: String) {
+        viewModelScope.launch {
+            Log.i("MAP_VIEWMODEL", "searchStores API 호출 요청: keyword=$keyword, lat=$currentLatitude, lng=$currentLongitude")
+            val stores = storeRepository.searchStores(
+                keyword = keyword,
+                type = "ALL",
+                lat = currentLatitude,
+                lng = currentLongitude
+            )
+            _nearbyStores.value = stores
         }
     }
 

--- a/app/src/main/java/com/example/pickitpickit/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/mypage/MyPageScreen.kt
@@ -1,34 +1,709 @@
 package com.example.pickitpickit.ui.mypage
 
+import android.Manifest
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ExitToApp
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.app.NotificationManagerCompat
+import kotlinx.coroutines.launch
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.example.pickitpickit.R
+import com.example.pickitpickit.core.model.InterestTagResponse
+import com.example.pickitpickit.ui.theme.PickitPickitTheme
 
 @Composable
-fun MyPageScreen(onLogoutClick: () -> Unit) {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(text = "마이페이지", fontSize = 24.sp, fontWeight = FontWeight.Bold)
-        Spacer(modifier = Modifier.height(24.dp))
-        Button(
-            onClick = onLogoutClick,
-            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF4D4D)),
-            shape = RoundedCornerShape(12.dp),
-            contentPadding = PaddingValues(horizontal = 24.dp, vertical = 12.dp)
-        ) {
-            Text(text = "임시 로그아웃 🚪", color = Color.White, fontSize = 16.sp, fontWeight = FontWeight.Bold)
+fun MyPageScreen(
+    onLogoutClick: () -> Unit,
+    myPageViewModel: MyPageViewModel = viewModel()
+) {
+    val uiState by myPageViewModel.uiState.collectAsState()
+    var showProfileEdit by remember { mutableStateOf(false) }
+
+    LaunchedEffect(Unit) {
+        myPageViewModel.loadUserProfile()
+    }
+
+    // 에러 다이얼로그
+    if (uiState.errorMessage != null) {
+        AlertDialog(
+            onDismissRequest = myPageViewModel::clearError,
+            confirmButton = {
+                TextButton(onClick = myPageViewModel::clearError) {
+                    Text("확인", color = Color(0xFF5393FA), fontWeight = FontWeight.Bold)
+                }
+            },
+            title = { Text("알림", fontWeight = FontWeight.Bold) },
+            text = { Text(uiState.errorMessage ?: "") }
+        )
+    }
+
+    // 프로필 편집 화면 오버레이
+    if (showProfileEdit) {
+        ProfileEditScreen(
+            uiState = uiState,
+            onNicknameChange = myPageViewModel::updateEditNickname,
+            onSelectImage = myPageViewModel::selectEditProfileImage,
+            onToggleTag = myPageViewModel::toggleEditTag,
+            onAddCustomTag = myPageViewModel::addCustomTag,
+            onRemoveTag = myPageViewModel::removeSelectedTag,
+            onCustomTagInputChange = myPageViewModel::updateCustomTagInput,
+            onSave = {
+                myPageViewModel.saveProfile {
+                    showProfileEdit = false
+                }
+            },
+            onCancel = {
+                myPageViewModel.resetEditState()
+                showProfileEdit = false
+            }
+        )
+        return
+    }
+
+    MyPageScreenContent(
+        uiState = uiState,
+        onLogoutClick = onLogoutClick,
+        onEditClick = {
+            myPageViewModel.resetEditState()
+            showProfileEdit = true
         }
+    )
+}
+
+@Composable
+internal fun MyPageScreenContent(
+    uiState: MyPageState,
+    onLogoutClick: () -> Unit,
+    onEditClick: () -> Unit
+) {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val userPreferences = com.example.pickitpickit.GlobalApplication.userPreferences
+
+    // 현재 알림 허용 여부 상태 (코루튼 재시작 시 자동 갱신)
+    var notificationsEnabled by remember {
+        mutableStateOf(NotificationManagerCompat.from(context).areNotificationsEnabled())
+    }
+
+    // 로컬 푸시 알림 설정 값 (기본값 true)
+    val localPushEnabled by userPreferences.isPushNotificationsEnabled.collectAsState(initial = true)
+
+    // 로컬 검색 반경 설정 값 (기본값 1000m = 1km)
+    val searchRadius by userPreferences.searchRadius.collectAsState(initial = 1000)
+    var showRadiusDialog by remember { mutableStateOf(false) }
+
+    // 최종 사용자 알림 활성화 여부
+    val isNotificationsOn = notificationsEnabled && localPushEnabled
+
+    // Android 13+ 시스템 알림 권한 요청 launcher
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted ->
+        notificationsEnabled = granted
+        if (granted) {
+            coroutineScope.launch {
+                userPreferences.setPushNotificationsEnabled(true)
+            }
+        }
+    }
+
+    val backgroundBrush = Brush.horizontalGradient(
+        colors = listOf(
+            Color(0xFF2ACAE7),
+            Color(0xFF4D6FDF)
+        )
+    )
+
+    val scrollState = rememberScrollState()
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+        ) {
+            // ── 상단 그라데이션 배너 ──────────────────────────────
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(brush = backgroundBrush)
+                    .padding(top = 56.dp, bottom = 32.dp, start = 24.dp, end = 24.dp),
+                contentAlignment = Alignment.TopCenter
+            ) {
+                Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                    Image(
+                        painter = painterResource(id = R.drawable.logo_pikipiki),
+                        contentDescription = "앱 로고",
+                        modifier = Modifier
+                            .width(120.dp)
+                            .aspectRatio(1.5f)
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text(
+                        text = "앱 환경을 커스터마이징하세요",
+                        color = Color(0xFF6B4B20).copy(alpha = 0.75f),
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+
+            // ── 콘텐츠 영역 ───────────────────────────────────
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFFF5F7FA))
+                    .padding(horizontal = 16.dp)
+                    .padding(bottom = 100.dp)
+            ) {
+
+                // 프로필 섹션 레이블
+                SectionLabel(text = "프로필")
+
+                // 프로필 카드
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .shadow(elevation = 6.dp, shape = RoundedCornerShape(16.dp), spotColor = Color(0x1A000000))
+                        .background(Color.White, RoundedCornerShape(16.dp))
+                        .padding(16.dp)
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        // 원형 프로필 이미지
+                        Box(
+                            modifier = Modifier
+                                .size(64.dp)
+                                .clip(CircleShape)
+                                .background(Color(0xFFE8F0FF))
+                                .border(2.dp, Color(0xFF5393FA), CircleShape),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            if (!uiState.profileImageUrl.isNullOrEmpty()) {
+                                AsyncImage(
+                                    model = uiState.profileImageUrl,
+                                    contentDescription = "프로필 이미지",
+                                    modifier = Modifier.fillMaxSize().clip(CircleShape),
+                                    contentScale = ContentScale.Crop
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.Default.Person,
+                                    contentDescription = null,
+                                    tint = Color(0xFF5393FA),
+                                    modifier = Modifier.size(36.dp)
+                                )
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.width(14.dp))
+
+                        Column(modifier = Modifier.weight(1f)) {
+                            if (uiState.isLoading) {
+                                Text("불러오는 중...", color = Color.Gray, fontSize = 14.sp)
+                            } else {
+                                Text(
+                                    text = uiState.nickname.ifEmpty { "닉네임 없음" },
+                                    fontSize = 17.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = Color(0xFF1A1A2E),
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                Spacer(modifier = Modifier.height(2.dp))
+                                if (!uiState.kakaoEmail.isNullOrEmpty()) {
+                                    Text(
+                                        text = uiState.kakaoEmail,
+                                        fontSize = 12.sp,
+                                        color = Color(0xFF6A7282),
+                                        fontWeight = FontWeight.Medium
+                                    )
+                                } else if (!uiState.kakaoProfileImageUrl.isNullOrEmpty()) {
+                                    Text(
+                                        text = "카카오 계정 연동",
+                                        fontSize = 12.sp,
+                                        color = Color(0xFF6A7282),
+                                        fontWeight = FontWeight.Medium
+                                    )
+                                }
+                                Spacer(modifier = Modifier.height(6.dp))
+                                if (uiState.selectedTags.isNotEmpty()) {
+                                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        uiState.selectedTags.take(3).forEach { tag ->
+                                            TagChip(tag = tag)
+                                        }
+                                        if (uiState.selectedTags.size > 3) {
+                                            Text(
+                                                text = "+${uiState.selectedTags.size - 3}",
+                                                fontSize = 11.sp,
+                                                color = Color.Gray,
+                                                modifier = Modifier.align(Alignment.CenterVertically)
+                                            )
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // 편집 버튼 (우측 상단)
+                    TextButton(
+                        onClick = onEditClick,
+                        modifier = Modifier.align(Alignment.TopEnd),
+                        contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Edit,
+                            contentDescription = "편집",
+                            tint = Color(0xFF5393FA),
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(3.dp))
+                        Text("편집", color = Color(0xFF5393FA), fontSize = 13.sp, fontWeight = FontWeight.SemiBold)
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                SectionLabel(text = "계정")
+                SettingsCard {
+                    SettingsItem(
+                        icon = Icons.AutoMirrored.Filled.ExitToApp,
+                        iconTint = Color(0xFF5393FA),
+                        title = "로그아웃",
+                        subtitle = "계정에서 로그아웃"
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                SectionLabel(text = "위치 설정")
+                SettingsCard {
+                    val radiusSubtitle = when (searchRadius) {
+                        500 -> "500미터 (500m)"
+                        1000 -> "1 킬로미터 (1km)"
+                        3000 -> "3 킬로미터 (3km)"
+                        5000 -> "5 킬로미터 (5km)"
+                        else -> "${searchRadius / 1000.0} 킬로미터"
+                    }
+                    SettingsItem(
+                        iconRes = R.drawable.ic_distance,
+                        iconTint = Color(0xFF5393FA),
+                        title = "거리 단위",
+                        subtitle = radiusSubtitle,
+                        onClick = { showRadiusDialog = true }
+                    )
+                    HorizontalDivider(color = Color(0xFFF0F0F0), thickness = 0.7.dp)
+                    SettingsItem(
+                        iconRes = R.drawable.ic_location,
+                        iconTint = Color(0xFF5393FA),
+                        title = "자동 위치 갱신",
+                        subtitle = "앱 실행 시 자동으로 현재 위치 불러오기"
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                SectionLabel(text = "알림 설정")
+                SettingsCard {
+                    SettingsItem(
+                        icon = Icons.Default.Notifications,
+                        iconTint = Color(0xFF5393FA),
+                        title = "푸시 알림",
+                        subtitle = if (isNotificationsOn) "켜짐" else "꺼짐",
+                        onClick = {
+                            val systemEnabled = NotificationManagerCompat.from(context).areNotificationsEnabled()
+                            if (!systemEnabled) {
+                                // 1. 시스템 권한이 비활성화 상태이면 권한 요청 또는 앱 설정창으로 유도
+                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                    notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                                } else {
+                                    val intent = android.content.Intent(android.provider.Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+                                        putExtra(android.provider.Settings.EXTRA_APP_PACKAGE, context.packageName)
+                                    }
+                                    context.startActivity(intent)
+                                }
+                            } else {
+                                // 2. 시스템 권한이 활성화 상태이면, 로컬 푸시 알림 허용 여부를 반대로 토글!
+                                coroutineScope.launch {
+                                    userPreferences.setPushNotificationsEnabled(!localPushEnabled)
+                                }
+                            }
+                        }
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                SectionLabel(text = "화면 설정")
+                SettingsCard {
+                    SettingsItem(
+                        iconRes = R.drawable.ic_tema,
+                        iconTint = Color(0xFF5393FA),
+                        title = "테마",
+                        subtitle = "라이트 모드"
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                SectionLabel(text = "앱 정보")
+                SettingsCard {
+                    SettingsItem(
+                        icon = Icons.Default.Info,
+                        iconTint = Color(0xFF5393FA),
+                        title = "버전 정보",
+                        subtitle = "1.0.0"
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(
+                            brush = Brush.horizontalGradient(
+                                listOf(Color(0xFFFFA726), Color(0xFFFFD54F))
+                            ),
+                            shape = RoundedCornerShape(16.dp)
+                        )
+                        .padding(18.dp)
+                ) {
+                    Column {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Text("⭐", fontSize = 16.sp)
+                            Spacer(modifier = Modifier.width(6.dp))
+                            Text(
+                                text = "기본 설정 안내",
+                                fontWeight = FontWeight.Bold,
+                                fontSize = 14.sp,
+                                color = Color(0xFF4A2800)
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(10.dp))
+                        Text("✓ 기본 검색 거리: 3km", fontSize = 12.sp, color = Color(0xFF5A3400))
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text("✓ 거리 필터는 0.5km ~ 10km까지 설정 가능합니다", fontSize = 12.sp, color = Color(0xFF5A3400))
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Image(
+                        painter = painterResource(id = R.drawable.logo_pikipiki),
+                        contentDescription = "앱 로고",
+                        modifier = Modifier
+                            .width(90.dp)
+                            .aspectRatio(1.5f)
+                            .alpha(0.35f)
+                    )
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Text("샒끄샘끊 - 인형뚝기 & 가차 찾기", fontSize = 11.sp, color = Color.Gray)
+                    Text("© 2026 PikiPiki. All rights reserved.", fontSize = 10.sp, color = Color.LightGray)
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Button(
+                    onClick = onLogoutClick,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(52.dp),
+                    shape = RoundedCornerShape(14.dp),
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF4444))
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ExitToApp,
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(20.dp)
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(
+                        text = "로그아웃",
+                        color = Color.White,
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 16.sp
+                    )
+                }
+            }
+        }
+
+        if (uiState.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.25f))
+                    .clickable(enabled = false) {},
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = Color(0xFF5393FA))
+            }
+        }
+
+        if (showRadiusDialog) {
+            val options = listOf(
+                500 to "500미터 (500m)",
+                1000 to "1 킬로미터 (1km)",
+                3000 to "3 킬로미터 (3km)",
+                5000 to "5 킬로미터 (5km)"
+            )
+
+            AlertDialog(
+                onDismissRequest = { showRadiusDialog = false },
+                title = {
+                    Text(
+                        text = "검색 반경 설정",
+                        fontWeight = FontWeight.Bold,
+                        fontSize = 18.sp,
+                        color = Color(0xFF1A1A2E)
+                    )
+                },
+                text = {
+                    Column(modifier = Modifier.fillMaxWidth().padding(top = 8.dp)) {
+                        options.forEach { (value, label) ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        coroutineScope.launch {
+                                            userPreferences.setSearchRadius(value)
+                                            showRadiusDialog = false
+                                        }
+                                    }
+                                    .padding(vertical = 12.dp, horizontal = 8.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                RadioButton(
+                                    selected = (searchRadius == value),
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            userPreferences.setSearchRadius(value)
+                                            showRadiusDialog = false
+                                        }
+                                    },
+                                    colors = RadioButtonDefaults.colors(selectedColor = Color(0xFF5393FA))
+                                )
+                                Spacer(modifier = Modifier.width(8.dp))
+                                Text(
+                                    text = label,
+                                    fontSize = 15.sp,
+                                    color = Color(0xFF1A1A2E),
+                                    fontWeight = if (searchRadius == value) FontWeight.Bold else FontWeight.Normal
+                                )
+                            }
+                        }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { showRadiusDialog = false }) {
+                        Text("닫기", color = Color(0xFF5393FA), fontWeight = FontWeight.Bold)
+                    }
+                },
+                shape = RoundedCornerShape(16.dp),
+                containerColor = Color.White
+            )
+        }
+    }
+}
+
+@Composable
+private fun SectionLabel(text: String) {
+    Text(
+        text = text,
+        fontSize = 13.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = Color(0xFF888888),
+        modifier = Modifier.padding(start = 4.dp, top = 4.dp, bottom = 8.dp)
+    )
+}
+
+@Composable
+private fun SettingsCard(content: @Composable ColumnScope.() -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(elevation = 4.dp, shape = RoundedCornerShape(14.dp), spotColor = Color(0x0F000000))
+            .background(Color.White, RoundedCornerShape(14.dp))
+    ) {
+        content()
+    }
+}
+
+@Composable
+private fun SettingsItem(
+    icon: ImageVector,
+    iconTint: Color,
+    title: String,
+    subtitle: String,
+    onClick: (() -> Unit)? = null
+) {
+    SettingsItemContent(
+        iconPainter = androidx.compose.ui.graphics.vector.rememberVectorPainter(image = icon),
+        iconTint = iconTint,
+        title = title,
+        subtitle = subtitle,
+        onClick = onClick
+    )
+}
+
+@Composable
+private fun SettingsItem(
+    iconRes: Int,
+    iconTint: Color,
+    title: String,
+    subtitle: String,
+    onClick: (() -> Unit)? = null
+) {
+    SettingsItemContent(
+        iconPainter = painterResource(id = iconRes),
+        iconTint = iconTint,
+        title = title,
+        subtitle = subtitle,
+        onClick = onClick
+    )
+}
+
+@Composable
+private fun SettingsItemContent(
+    iconPainter: androidx.compose.ui.graphics.painter.Painter,
+    iconTint: Color,
+    title: String,
+    subtitle: String,
+    onClick: (() -> Unit)? = null
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .then(if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(
+            modifier = Modifier
+                .size(38.dp)
+                .background(Color(0xFFEEF4FF), RoundedCornerShape(10.dp)),
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                painter = iconPainter,
+                contentDescription = null,
+                tint = iconTint,
+                modifier = Modifier.size(20.dp)
+            )
+        }
+        Spacer(modifier = Modifier.width(14.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(title, fontWeight = FontWeight.Medium, fontSize = 14.sp, color = Color(0xFF1A1A2E))
+            Text(subtitle, fontSize = 12.sp, color = Color(0xFF888888))
+        }
+        Icon(
+            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = null,
+            tint = Color(0xFFBBBBBB),
+            modifier = Modifier.size(20.dp)
+        )
+    }
+}
+
+@Composable
+private fun TagChip(tag: InterestTagResponse) {
+    Box(
+        modifier = Modifier
+            .background(Color(0xFFFEF9C2), RoundedCornerShape(20.dp))
+            .border(1.dp, Color(0xFFFFDF20), RoundedCornerShape(20.dp))
+            .padding(horizontal = 8.dp, vertical = 3.dp)
+    ) {
+        Text(
+            text = "#${tag.name}",
+            fontSize = 11.sp,
+            color = Color(0xFF7A5500),
+            fontWeight = FontWeight.Medium
+        )
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Previews
+// ──────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, showSystemUi = true, name = "마이페이지 - 데이터 로드 완료")
+@Composable
+fun MyPageScreenPreview() {
+    PickitPickitTheme {
+        val dummyState = MyPageState(
+            nickname = "후훗나란남자란",
+            profileImageUrl = null,
+            profileImageType = "DEFAULT",
+            selectedTags = listOf(
+                InterestTagResponse(1L, "드래곤볼"),
+                InterestTagResponse(2L, "포켓몬"),
+                InterestTagResponse(3L, "디즈니")
+            ),
+            kakaoProfileImageUrl = null,
+            isLoading = false
+        )
+        // ViewModel 없이 State만으로 UI 렌더링하는 Preview 전용 내부 Composable
+        MyPageScreenContent(
+            uiState = dummyState,
+            onLogoutClick = {},
+            onEditClick = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true, name = "마이페이지 - 로딩 중")
+@Composable
+fun MyPageScreenLoadingPreview() {
+    PickitPickitTheme {
+        MyPageScreenContent(
+            uiState = MyPageState(isLoading = true),
+            onLogoutClick = {},
+            onEditClick = {}
+        )
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/mypage/MyPageViewModel.kt
@@ -1,0 +1,276 @@
+package com.example.pickitpickit.ui.mypage
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.pickitpickit.core.model.DefaultProfileImageResponse
+import com.example.pickitpickit.core.model.InterestTagResponse
+import com.example.pickitpickit.core.network.OnboardingRepository
+import com.kakao.sdk.user.UserApiClient
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class MyPageState(
+    val nickname: String = "",
+    val profileImageUrl: String? = null,
+    val profileImageType: String = "DEFAULT",
+    val selectedTags: List<InterestTagResponse> = emptyList(),
+    val userId: Long = 0,
+    val kakaoProfileImageUrl: String? = null,
+    val kakaoEmail: String = "",
+    
+    // Default Images and tags for profile editing
+    val defaultProfileImages: List<DefaultProfileImageResponse> = emptyList(),
+    val backendDefaultProfileImages: List<DefaultProfileImageResponse> = emptyList(),
+    val availableTags: List<InterestTagResponse> = emptyList(),
+    
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null,
+    
+    // UI Local State for Profile Edit Form
+    val editNickname: String = "",
+    val editProfileImageUrl: String? = null,
+    val editProfileImageType: String = "DEFAULT",
+    val editSelectedTagIds: Set<Long> = emptySet(),
+    val customTagInput: String = ""
+)
+
+class MyPageViewModel : ViewModel() {
+    private val repository = OnboardingRepository()
+
+    private val _uiState = MutableStateFlow(MyPageState())
+    val uiState: StateFlow<MyPageState> = _uiState.asStateFlow()
+
+    init {
+        loadUserProfile()
+    }
+
+    fun loadUserProfile() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            
+            // 6종 고품질 로컬 Unsplash 기본 이미지 리스트 정의 (OnboardingViewModel과 통일)
+            val defaultUnsplashImages = listOf(
+                DefaultProfileImageResponse("1", "https://images.unsplash.com/photo-1534528741775-53994a69daeb?auto=format&fit=crop&w=300&q=80"),
+                DefaultProfileImageResponse("2", "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&w=300&q=80"),
+                DefaultProfileImageResponse("3", "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=300&q=80"),
+                DefaultProfileImageResponse("4", "https://images.unsplash.com/photo-1500648767791-00dcc994a43e?auto=format&fit=crop&w=300&q=80"),
+                DefaultProfileImageResponse("5", "https://images.unsplash.com/photo-1544005313-94ddf0286df2?auto=format&fit=crop&w=300&q=80"),
+                DefaultProfileImageResponse("6", "https://images.unsplash.com/photo-1522075469751-3a6694fb2f61?auto=format&fit=crop&w=300&q=80")
+            )
+
+            val status = repository.getOnboardingStatus()
+            val imagesOption = repository.getProfileImages()
+            var tags = repository.getInterestTags()
+
+            if (tags.isEmpty()) {
+                tags = listOf(
+                    InterestTagResponse(1L, "포켓몬"),
+                    InterestTagResponse(2L, "디즈니"),
+                    InterestTagResponse(3L, "원피스"),
+                    InterestTagResponse(4L, "산리오"),
+                    InterestTagResponse(5L, "마블"),
+                    InterestTagResponse(6L, "BT21"),
+                    InterestTagResponse(7L, "짱구"),
+                    InterestTagResponse(8L, "팬텀"),
+                    InterestTagResponse(9L, "귀멸의칼날"),
+                    InterestTagResponse(10L, "나루토"),
+                    InterestTagResponse(11L, "카카오"),
+                    InterestTagResponse(12L, "지브리"),
+                    InterestTagResponse(13L, "메이플"),
+                    InterestTagResponse(14L, "스누피"),
+                    InterestTagResponse(15L, "드래곤볼")
+                )
+            }
+
+            if (status != null) {
+                val finalImagesOption = com.example.pickitpickit.core.model.ProfileImageOptionsResponse(
+                    kakaoProfileImageUrl = imagesOption?.kakaoProfileImageUrl ?: status.kakaoProfileImageUrl,
+                    defaultImages = defaultUnsplashImages
+                )
+
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        nickname = status.nickname ?: "",
+                        profileImageUrl = status.profileImageUrl ?: (finalImagesOption.defaultImages.firstOrNull()?.imageUrl),
+                        profileImageType = status.profileImageType ?: "DEFAULT",
+                        selectedTags = status.selectedTags,
+                        userId = status.userId,
+                        kakaoProfileImageUrl = finalImagesOption.kakaoProfileImageUrl,
+                        defaultProfileImages = finalImagesOption.defaultImages,
+                        backendDefaultProfileImages = imagesOption?.defaultImages ?: emptyList(),
+                        availableTags = tags,
+                        isLoading = false
+                    )
+                }
+                resetEditState()
+                
+                // 카카오 SDK를 이용한 실제 사용자 이메일 정보 동적 조회
+                UserApiClient.instance.me { user, error ->
+                    if (error != null) {
+                        Log.e("KAKAO_ME", "카카오 사용자 정보 조회 실패 ❌", error)
+                    } else if (user != null) {
+                        Log.i("KAKAO_ME", "카카오 사용자 정보 조회 성공 🏆 | email = ${user.kakaoAccount?.email}")
+                    }
+                    val email = if (error == null && user != null) {
+                        user.kakaoAccount?.email ?: ""
+                    } else {
+                        ""
+                    }
+                    _uiState.update { it.copy(kakaoEmail = email) }
+                }
+            } else {
+                _uiState.update { it.copy(isLoading = false, errorMessage = "유저 정보를 불러올 수 없습니다.") }
+            }
+        }
+    }
+
+    fun resetEditState() {
+        _uiState.update { currentState ->
+            currentState.copy(
+                editNickname = currentState.nickname,
+                editProfileImageUrl = currentState.profileImageUrl,
+                editProfileImageType = currentState.profileImageType,
+                editSelectedTagIds = currentState.selectedTags.map { it.id }.toSet(),
+                customTagInput = ""
+            )
+        }
+    }
+
+    fun updateEditNickname(name: String) {
+        if (name.length <= 10) {
+            _uiState.update { it.copy(editNickname = name) }
+        }
+    }
+
+    fun selectEditProfileImage(type: String, url: String) {
+        _uiState.update { it.copy(editProfileImageUrl = url, editProfileImageType = type) }
+    }
+
+    fun toggleEditTag(tagId: Long) {
+        _uiState.update { currentState ->
+            val updated = currentState.editSelectedTagIds.toMutableSet()
+            if (updated.contains(tagId)) {
+                updated.remove(tagId)
+            } else {
+                updated.add(tagId)
+            }
+            currentState.copy(editSelectedTagIds = updated)
+        }
+    }
+
+    fun addCustomTag(tagName: String) {
+        val trimmed = tagName.trim()
+        if (trimmed.isEmpty() || trimmed.length > 10) return
+        
+        // Find if tag already exists in availableTags, if so toggle it. Otherwise add dynamically.
+        val existingTag = _uiState.value.availableTags.find { it.name == trimmed }
+        if (existingTag != null) {
+            _uiState.update { currentState ->
+                val updated = currentState.editSelectedTagIds.toMutableSet()
+                updated.add(existingTag.id)
+                currentState.copy(editSelectedTagIds = updated, customTagInput = "")
+            }
+        } else {
+            // Dynamically assign an ID
+            val newId = (_uiState.value.availableTags.map { it.id }.maxOrNull() ?: 0L) + 100L
+            val newTag = InterestTagResponse(newId, trimmed)
+            _uiState.update { currentState ->
+                val updatedTags = currentState.availableTags + newTag
+                val updatedSelected = currentState.editSelectedTagIds + newId
+                currentState.copy(
+                    availableTags = updatedTags,
+                    editSelectedTagIds = updatedSelected,
+                    customTagInput = ""
+                )
+            }
+        }
+    }
+
+    fun removeSelectedTag(tagId: Long) {
+        _uiState.update { currentState ->
+            val updated = currentState.editSelectedTagIds.toMutableSet()
+            updated.remove(tagId)
+            currentState.copy(editSelectedTagIds = updated)
+        }
+    }
+
+    fun updateCustomTagInput(input: String) {
+        if (input.length <= 10) {
+            _uiState.update { it.copy(customTagInput = input) }
+        }
+    }
+
+    fun saveProfile(onSuccess: () -> Unit) {
+        val finalNickname = _uiState.value.editNickname.trim()
+        if (finalNickname.length < 2) {
+            _uiState.update { it.copy(errorMessage = "닉네임은 2자 이상 입력해주세요.") }
+            return
+        }
+
+        val finalUrl = _uiState.value.editProfileImageUrl
+        val type = _uiState.value.editProfileImageType
+        if (finalUrl.isNullOrEmpty()) {
+            _uiState.update { it.copy(errorMessage = "프로필 이미지를 선택해 주세요.") }
+            return
+        }
+
+        // Map UI image to backend relative path (using index)
+        val backendUrl = if (type == "DEFAULT") {
+            val unsplashList = _uiState.value.defaultProfileImages
+            val backendList = _uiState.value.backendDefaultProfileImages
+            val index = unsplashList.indexOfFirst { it.imageUrl == finalUrl }
+            if (index in 0 until backendList.size) {
+                backendList[index].imageUrl
+            } else {
+                finalUrl
+            }
+        } else if (type == "KAKAO") {
+            if (finalUrl.startsWith("https://k.kakaocdn.net")) {
+                finalUrl.replace("https://k.kakaocdn.net", "http://k.kakaocdn.net")
+            } else {
+                finalUrl
+            }
+        } else {
+            finalUrl
+        }
+
+        val tagIds = _uiState.value.editSelectedTagIds.toList()
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            
+            // 1. Update Nickname
+            val nicknameError = repository.updateNickname(finalNickname)
+            if (nicknameError != null) {
+                _uiState.update { it.copy(isLoading = false, errorMessage = nicknameError) }
+                return@launch
+            }
+
+            // 2. Update Profile Image
+            val imageSuccess = repository.updateProfileImage(type, backendUrl)
+            if (!imageSuccess) {
+                _uiState.update { it.copy(isLoading = false, errorMessage = "프로필 이미지 저장에 실패했습니다.") }
+                return@launch
+            }
+
+            // 3. Update Tags
+            val tagsError = repository.updateInterestTags(tagIds)
+            if (tagsError != null) {
+                _uiState.update { it.copy(isLoading = false, errorMessage = tagsError) }
+                return@launch
+            }
+
+            // Reload profile data to synchronize
+            loadUserProfile()
+            onSuccess()
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/mypage/ProfileEditScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/mypage/ProfileEditScreen.kt
@@ -1,0 +1,488 @@
+package com.example.pickitpickit.ui.mypage
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.tooling.preview.Preview
+import coil.compose.AsyncImage
+import com.example.pickitpickit.core.model.DefaultProfileImageResponse
+import com.example.pickitpickit.core.model.InterestTagResponse
+import com.example.pickitpickit.ui.theme.PickitPickitTheme
+import com.example.pickitpickit.ui.theme.Variables
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun ProfileEditScreen(
+    uiState: MyPageState,
+    onNicknameChange: (String) -> Unit,
+    onSelectImage: (type: String, url: String) -> Unit,
+    onToggleTag: (Long) -> Unit,
+    onAddCustomTag: (String) -> Unit,
+    onRemoveTag: (Long) -> Unit,
+    onCustomTagInputChange: (String) -> Unit,
+    onSave: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val scrollState = rememberScrollState()
+    val imageScrollState = rememberScrollState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF5F7FA))
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(bottom = 90.dp)
+        ) {
+            // ── 상단 헤더 ─────────────────────────────────────────────
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        Brush.horizontalGradient(
+                            listOf(Color(0xFF5393FA), Color(0xFF7B6EF6))
+                        )
+                    )
+                    .padding(top = 52.dp, bottom = 24.dp, start = 20.dp, end = 20.dp)
+            ) {
+                Text(
+                    text = "프로필",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 20.sp,
+                    color = Color.White,
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp)
+            ) {
+                // ── 닉네임 섹션 ───────────────────────────────────────
+                EditSectionLabel(text = "닉네임 (2~10자)")
+
+                OutlinedTextField(
+                    value = uiState.editNickname,
+                    onValueChange = onNicknameChange,
+                    modifier = Modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(12.dp),
+                    singleLine = true,
+                    colors = OutlinedTextFieldDefaults.colors(
+                        focusedBorderColor = Variables.Blue500,
+                        unfocusedBorderColor = Color(0xFFDDE3F0)
+                    )
+                )
+                Text(
+                    text = "${uiState.editNickname.length}/10자",
+                    fontSize = 11.sp,
+                    color = Color.Gray,
+                    modifier = Modifier
+                        .align(Alignment.End)
+                        .padding(top = 4.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // ── 프로필 이미지 섹션 ────────────────────────────────
+                EditSectionLabel(text = "프로필 이미지")
+
+                // 대형 현재 선택 이미지 중앙 표시
+                Box(
+                    modifier = Modifier
+                        .size(90.dp)
+                        .align(Alignment.CenterHorizontally)
+                        .clip(CircleShape)
+                        .border(3.dp, Variables.Blue500, CircleShape)
+                        .background(Color(0xFFE8F0FF)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (!uiState.editProfileImageUrl.isNullOrEmpty()) {
+                        AsyncImage(
+                            model = uiState.editProfileImageUrl,
+                            contentDescription = "선택된 프로필",
+                            modifier = Modifier.fillMaxSize().clip(CircleShape),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Icon(
+                            imageVector = Icons.Default.Person,
+                            contentDescription = null,
+                            tint = Variables.Blue500,
+                            modifier = Modifier.size(48.dp)
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(14.dp))
+
+                // 가로 스크롤 이미지 썸네일 목록
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .horizontalScroll(imageScrollState),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    // 카카오 이미지가 있는 경우 표시
+                    if (!uiState.kakaoProfileImageUrl.isNullOrEmpty()) {
+                        val isSelected = uiState.editProfileImageUrl == uiState.kakaoProfileImageUrl
+                        ProfileImageThumb(
+                            imageUrl = uiState.kakaoProfileImageUrl!!,
+                            isSelected = isSelected,
+                            label = "카카오",
+                            onClick = { onSelectImage("KAKAO", uiState.kakaoProfileImageUrl!!) }
+                        )
+                    }
+                    uiState.defaultProfileImages.forEach { img ->
+                        val isSelected = uiState.editProfileImageUrl == img.imageUrl
+                        ProfileImageThumb(
+                            imageUrl = img.imageUrl,
+                            isSelected = isSelected,
+                            onClick = { onSelectImage("DEFAULT", img.imageUrl) }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(10.dp))
+
+                // 앨범에서 가져오기 버튼 (추후 구현)
+                OutlinedButton(
+                    onClick = { /* TODO: 갤러리 선택 구현 */ },
+                    modifier = Modifier.fillMaxWidth().height(44.dp),
+                    shape = RoundedCornerShape(12.dp),
+                    border = BorderStroke(1.dp, Color(0xFFCBD5E1))
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text("앨범에서 가져오기", fontSize = 13.sp)
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // ── 관심 태그 섹션 ────────────────────────────────────
+                val selectedTagIds = uiState.editSelectedTagIds
+                val allTags = uiState.availableTags
+                val selectedTagObjects = allTags.filter { it.id in selectedTagIds }
+
+                EditSectionLabel(text = "관심 태그 (1개 선택필)")
+
+                // 태그 직접 입력
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    OutlinedTextField(
+                        value = uiState.customTagInput,
+                        onValueChange = onCustomTagInputChange,
+                        modifier = Modifier.weight(1f),
+                        shape = RoundedCornerShape(12.dp),
+                        singleLine = true,
+                        placeholder = { Text("직접 입력 (10자 이하)", fontSize = 13.sp, color = Color.LightGray) },
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedBorderColor = Variables.Blue500,
+                            unfocusedBorderColor = Color(0xFFDDE3F0)
+                        )
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(
+                        onClick = { onAddCustomTag(uiState.customTagInput) },
+                        enabled = uiState.customTagInput.trim().length in 1..10,
+                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFEE500)),
+                        shape = RoundedCornerShape(12.dp),
+                        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 0.dp),
+                        modifier = Modifier.height(56.dp)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.Add,
+                            contentDescription = null,
+                            tint = Color(0xFF1A1A1A),
+                            modifier = Modifier.size(16.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                        Text("추가", color = Color(0xFF1A1A1A), fontWeight = FontWeight.Bold, fontSize = 13.sp)
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(12.dp))
+
+                // 내 태그 (선택된 태그들)
+                if (selectedTagObjects.isNotEmpty()) {
+                    Text("내 태그", fontSize = 12.sp, color = Color(0xFF888888), fontWeight = FontWeight.SemiBold)
+                    Spacer(modifier = Modifier.height(6.dp))
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(Color(0xFFFFF9E6), RoundedCornerShape(12.dp))
+                            .padding(12.dp)
+                    ) {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            selectedTagObjects.forEach { tag ->
+                                SelectedTagChip(
+                                    tagName = tag.name,
+                                    onRemove = { onRemoveTag(tag.id) }
+                                )
+                            }
+                        }
+                    }
+                    Spacer(modifier = Modifier.height(14.dp))
+                }
+
+                // 추천 태그
+                Text("추천 태그", fontSize = 12.sp, color = Color(0xFF888888), fontWeight = FontWeight.SemiBold)
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFFF0F0F0), RoundedCornerShape(12.dp))
+                        .padding(12.dp)
+                ) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        allTags.forEach { tag ->
+                            val isSelected = tag.id in selectedTagIds
+                            RecommendedTagChip(
+                                tagName = tag.name,
+                                isSelected = isSelected,
+                                onClick = { onToggleTag(tag.id) }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── 하단 고정 취소/저장 버튼 ──────────────────────────────────
+        Row(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(horizontal = 20.dp, vertical = 14.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedButton(
+                onClick = onCancel,
+                modifier = Modifier
+                    .weight(1f)
+                    .height(50.dp),
+                shape = RoundedCornerShape(14.dp),
+                border = BorderStroke(1.dp, Color(0xFFCBD5E1))
+            ) {
+                Text("취소", fontWeight = FontWeight.SemiBold)
+            }
+
+            Button(
+                onClick = onSave,
+                enabled = !uiState.isLoading && uiState.editNickname.length >= 2,
+                modifier = Modifier
+                    .weight(2f)
+                    .height(50.dp),
+                shape = RoundedCornerShape(14.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Variables.Blue500)
+            ) {
+                if (uiState.isLoading) {
+                    CircularProgressIndicator(color = Color.White, modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                } else {
+                    Icon(imageVector = Icons.Default.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(18.dp))
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text("저장", color = Color.White, fontWeight = FontWeight.Bold, fontSize = 15.sp)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun EditSectionLabel(text: String) {
+    Text(
+        text = text,
+        fontSize = 13.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = Color(0xFF555555),
+        modifier = Modifier.padding(bottom = 8.dp)
+    )
+}
+
+@Composable
+private fun ProfileImageThumb(
+    imageUrl: String,
+    isSelected: Boolean,
+    label: String? = null,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .size(60.dp)
+            .clip(CircleShape)
+            .border(if (isSelected) 3.dp else 1.5.dp, if (isSelected) Variables.Blue500 else Color.Transparent, CircleShape)
+            .clickable { onClick() },
+        contentAlignment = Alignment.Center
+    ) {
+        AsyncImage(
+            model = imageUrl,
+            contentDescription = label,
+            modifier = Modifier.fillMaxSize().clip(CircleShape),
+            contentScale = ContentScale.Crop
+        )
+        if (isSelected) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.35f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(Icons.Default.Check, contentDescription = null, tint = Color.White, modifier = Modifier.size(22.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun SelectedTagChip(tagName: String, onRemove: () -> Unit) {
+    Box(
+        modifier = Modifier
+            .background(Color(0xFFFEE500), RoundedCornerShape(20.dp))
+            .padding(horizontal = 10.dp, vertical = 5.dp)
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("#$tagName", fontSize = 12.sp, color = Color(0xFF4A3000), fontWeight = FontWeight.SemiBold)
+            Spacer(modifier = Modifier.width(4.dp))
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "삭제",
+                tint = Color(0xFF8A6000),
+                modifier = Modifier
+                    .size(14.dp)
+                    .clickable { onRemove() }
+            )
+        }
+    }
+}
+
+@Composable
+private fun RecommendedTagChip(tagName: String, isSelected: Boolean, onClick: () -> Unit) {
+    val bgColor = if (isSelected) Color(0xFFE8EEFF) else Color.White
+    val borderColor = if (isSelected) Variables.Blue500 else Color(0xFFDDE3F0)
+    val textColor = if (isSelected) Variables.Blue500 else Color(0xFF555555)
+
+    Box(
+        modifier = Modifier
+            .background(bgColor, RoundedCornerShape(20.dp))
+            .border(1.dp, borderColor, RoundedCornerShape(20.dp))
+            .clickable { onClick() }
+            .padding(horizontal = 12.dp, vertical = 6.dp)
+    ) {
+        Text(
+            text = "#$tagName",
+            fontSize = 12.sp,
+            color = textColor,
+            fontWeight = if (isSelected) FontWeight.SemiBold else FontWeight.Normal
+        )
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Previews
+// ──────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, showSystemUi = true, name = "프로필 편집 - 데이터 로드 완료")
+@Composable
+fun ProfileEditScreenPreview() {
+    PickitPickitTheme {
+        val dummyImages = listOf(
+            DefaultProfileImageResponse("1", "https://images.unsplash.com/photo-1534528741775-53994a69daeb?auto=format&fit=crop&w=300&q=80"),
+            DefaultProfileImageResponse("2", "https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?auto=format&fit=crop&w=300&q=80"),
+            DefaultProfileImageResponse("3", "https://images.unsplash.com/photo-1494790108377-be9c29b29330?auto=format&fit=crop&w=300&q=80")
+        )
+        val dummyTags = listOf(
+            InterestTagResponse(1L, "포켓몬"),
+            InterestTagResponse(2L, "디즈니"),
+            InterestTagResponse(3L, "마블"),
+            InterestTagResponse(4L, "짱구"),
+            InterestTagResponse(5L, "지브리")
+        )
+        val dummyState = MyPageState(
+            editNickname = "후훗나란남자란",
+            editProfileImageUrl = dummyImages.first().imageUrl,
+            editProfileImageType = "DEFAULT",
+            editSelectedTagIds = setOf(1L, 3L),
+            defaultProfileImages = dummyImages,
+            availableTags = dummyTags,
+            customTagInput = "",
+            isLoading = false
+        )
+        ProfileEditScreen(
+            uiState = dummyState,
+            onNicknameChange = {},
+            onSelectImage = { _, _ -> },
+            onToggleTag = {},
+            onAddCustomTag = {},
+            onRemoveTag = {},
+            onCustomTagInputChange = {},
+            onSave = {},
+            onCancel = {}
+        )
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true, name = "프로필 편집 - 저장 중")
+@Composable
+fun ProfileEditScreenSavingPreview() {
+    PickitPickitTheme {
+        val dummyState = MyPageState(
+            editNickname = "후훗나란남자란",
+            isLoading = true
+        )
+        ProfileEditScreen(
+            uiState = dummyState,
+            onNicknameChange = {},
+            onSelectImage = { _, _ -> },
+            onToggleTag = {},
+            onAddCustomTag = {},
+            onRemoveTag = {},
+            onCustomTagInputChange = {},
+            onSave = {},
+            onCancel = {}
+        )
+    }
+}
+

--- a/app/src/main/res/drawable/ic_distance.xml
+++ b/app/src/main/res/drawable/ic_distance.xml
@@ -1,0 +1,18 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M19.9929 9.99643C19.9929 14.9877 14.4558 20.1858 12.5965 21.7913C12.4233 21.9215 12.2124 21.9919 11.9957 21.9919C11.779 21.9919 11.5681 21.9215 11.3949 21.7913C9.53557 20.1858 3.99854 14.9877 3.99854 9.99643C3.99854 7.87545 4.84109 5.84134 6.34085 4.34158C7.84061 2.84182 9.87472 1.99927 11.9957 1.99927C14.1167 1.99927 16.1508 2.84182 17.6506 4.34158C19.1503 5.84134 19.9929 7.87545 19.9929 9.99643Z"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M11.9955 12.9954C13.6518 12.9954 14.9945 11.6527 14.9945 9.99643C14.9945 8.34017 13.6518 6.9975 11.9955 6.9975C10.3393 6.9975 8.99658 8.34017 8.99658 9.99643C8.99658 11.6527 10.3393 12.9954 11.9955 12.9954Z"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_location.xml
+++ b/app/src/main/res/drawable/ic_location.xml
@@ -1,0 +1,24 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M11.996 21.9922C17.5169 21.9922 21.9924 17.5166 21.9924 11.9957C21.9924 6.47483 17.5169 1.99927 11.996 1.99927C6.47508 1.99927 1.99951 6.47483 1.99951 11.9957C1.99951 17.5166 6.47508 21.9922 11.996 21.9922Z"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M11.9957 1.99927C9.4288 4.69447 7.99707 8.27378 7.99707 11.9957C7.99707 15.7177 9.4288 19.297 11.9957 21.9922C14.5625 19.297 15.9942 15.7177 15.9942 11.9957C15.9942 8.27378 14.5625 4.69447 11.9957 1.99927Z"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M1.99951 11.9957H21.9924"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+</vector>

--- a/app/src/main/res/drawable/ic_store_marker.xml
+++ b/app/src/main/res/drawable/ic_store_marker.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="20dp"
+    android:height="25dp"
+    android:viewportWidth="32"
+    android:viewportHeight="40">
+    <!-- 파란색 핀 몸통 (#3B6EF8) -->
+    <path
+        android:fillColor="#3B6EF8"
+        android:pathData="M16,0 C9.37,0 4,5.37 4,12 C4,20 16,40 16,40 C16,40 28,20 28,12 C28,5.37 22.63,0 16,0 Z"/>
+    <!-- 핀 중심 흰 원 -->
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M16,16 m-5,0 a5,5 0 1,0 10,0 a5,5 0 1,0 -10,0"/>
+</vector>

--- a/app/src/main/res/drawable/ic_tema.xml
+++ b/app/src/main/res/drawable/ic_tema.xml
@@ -1,0 +1,60 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:pathData="M11.9957 15.9944C14.204 15.9944 15.9942 14.2041 15.9942 11.9958C15.9942 9.78742 14.204 7.99719 11.9957 7.99719C9.7873 7.99719 7.99707 9.78742 7.99707 11.9958C7.99707 14.2041 9.7873 15.9944 11.9957 15.9944Z"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M11.9956 1.99927V3.99927"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M11.9956 19.9929V21.9929"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M4.92822 4.92822L6.33822 6.33822"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M17.6538 17.6537L19.0638 19.0637"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M1.99951 11.9957H3.99951"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M19.9927 11.9957H21.9927"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M6.33822 17.6537L4.92822 19.0637"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+    <path
+        android:pathData="M19.0638 4.92822L17.6538 6.33822"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1.99929"
+        android:strokeLineCap="round"
+        android:strokeLineJoin="round"/>
+</vector>


### PR DESCRIPTION
## 📌 관련 이슈
- Closes #21
- #22
## 🛠️ 작업 내용
이번 PR은 머지 충돌로 인해 유실되었던 마이페이지 기능 복구와, 현재 브랜치에서 진행 중이던 실시간 지도 핀 마커 렌더링 기능을 하나로 조화롭게 통합하고 빌드 안정성을 확보한 작업입니다.
### 1. 마이페이지 및 프로필 수정 복구 (#21)
- **유실 코드 복원**: `MyPageScreen`, `MyPageViewModel`, `ProfileEditScreen`을 이전 상태 그대로 완벽히 복원하였습니다.
- **토큰 자동 갱신**: HTTP 401 Unauthorized 발생 시 로컬 Refresh Token을 사용해 동기식으로 Access Token을 갱신하는 `AuthInterceptor` 로직을 복구했습니다.
- **메뉴 리소스**: 마이페이지 설정 메뉴에 필요한 SVG 아이콘 3종(`ic_distance`, `ic_location`, `ic_tema`)을 추가하였습니다.
- **미리보기(Preview)**: 안드로이드 스튜디오 디자인 패널에서 UI 상태를 확인할 수 있도록 Preview 코드를 탑재했습니다.
### 2. 검색 반경 및 실시간 지도 핀 마커 연동 (#22)
- **매장 API 통신 연동**: 반경 설정에 맞는 매장 목록을 불러오기 위한 `StoreApi`, `StoreRepository`, `StoreModels`를 설계하고 연동했습니다.
- **동적 마커 렌더링**: GPS 및 검색어 필터 갱신에 따라 카카오맵 객체의 마커 레이어 내에 파란색 매장 핀(`ic_store_marker`)이 실시간으로 꽂히고 지워지도록 라이프사이클을 연계하였습니다.