### PR TITLE
feat: Store 상세페이지 구현 및 API 연동

### DIFF
--- a/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
@@ -62,7 +62,10 @@ import com.kakao.vectormap.label.LabelStyle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HomeScreen(mapViewModel: MapViewModel) {
+fun HomeScreen(
+    mapViewModel: MapViewModel,
+    onStoreClick: (storeId: Int) -> Unit = {}
+) {
     val selectedCategory by mapViewModel.selectedCategory.collectAsState()
     val isBottomSheetVisible by mapViewModel.isBottomSheetVisible.collectAsState()
     val searchQuery by mapViewModel.searchQuery.collectAsState()
@@ -310,7 +313,8 @@ fun HomeScreen(mapViewModel: MapViewModel) {
         ) {
             NearbyStoreBottomSheet(
                 stores = filteredStores,
-                onClose = { mapViewModel.hideBottomSheet() }
+                onClose = { mapViewModel.hideBottomSheet() },
+                onStoreClick = onStoreClick
             )
         }
     }
@@ -682,7 +686,8 @@ fun NearbyRecommendButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
 @Composable
 fun NearbyStoreBottomSheet(
     stores: List<StoreItem>,
-    onClose: () -> Unit
+    onClose: () -> Unit,
+    onStoreClick: (Int) -> Unit = {}
 ) {
     Column(modifier = Modifier.fillMaxWidth()) {
         // 핸들
@@ -712,7 +717,10 @@ fun NearbyStoreBottomSheet(
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             items(stores) { store ->
-                StoreListItem(store = store)
+                StoreListItem(
+                    store = store,
+                    onClick = { onStoreClick(store.id) }
+                )
             }
             item { Spacer(modifier = Modifier.height(16.dp)) }
         }
@@ -723,7 +731,10 @@ fun NearbyStoreBottomSheet(
 // 매장 리스트 아이템
 // ────────────────────────────────────────────────────────────
 @Composable
-fun StoreListItem(store: StoreItem) {
+fun StoreListItem(
+    store: StoreItem,
+    onClick: () -> Unit = {}
+) {
     val categoryLabel = when (store.category) {
         MapCategory.CLAW_MACHINE -> "인형뽑기"
         MapCategory.GACHA -> "가챠"
@@ -738,7 +749,9 @@ fun StoreListItem(store: StoreItem) {
     }
 
     Card(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() },
         shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = Color.White),
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)

--- a/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
@@ -24,6 +24,13 @@ class MapViewModel : ViewModel() {
     private var currentLatitude: Double? = null
     private var currentLongitude: Double? = null
 
+    // 현재 위치 공개 StateFlow (StoreDetailViewModel에 전달용)
+    private val _userLatitude = MutableStateFlow<Double?>(null)
+    val userLatitude: StateFlow<Double?> = _userLatitude.asStateFlow()
+
+    private val _userLongitude = MutableStateFlow<Double?>(null)
+    val userLongitude: StateFlow<Double?> = _userLongitude.asStateFlow()
+
     // 카테고리 필터 상태
     private val _selectedCategory = MutableStateFlow(MapCategory.ALL)
     val selectedCategory: StateFlow<MapCategory> = _selectedCategory.asStateFlow()
@@ -69,6 +76,8 @@ class MapViewModel : ViewModel() {
     fun loadNearbyStores(latitude: Double, longitude: Double, type: String = "ALL") {
         currentLatitude = latitude
         currentLongitude = longitude
+        _userLatitude.value = latitude
+        _userLongitude.value = longitude
         viewModelScope.launch {
             // DataStore의 검색 반경 설정을 불러옴
             val radius = userPreferences.searchRadius.firstOrNull() ?: 1000

--- a/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
@@ -47,9 +47,20 @@ class MapViewModel : ViewModel() {
     private val _registeredTags = MutableStateFlow<List<String>>(listOf("#원피스", "#포켓몬", "#디즈니"))
     val registeredTags: StateFlow<List<String>> = _registeredTags.asStateFlow()
 
+    // 검색 반경 상태 구독 추가
+    private val _searchRadius = MutableStateFlow(1000)
+    val searchRadius: StateFlow<Int> = _searchRadius.asStateFlow()
+
     init {
         // 뷰모델 생성 시 서버에서 최근 검색어 불러오기
         loadRecentSearches()
+        
+        // DataStore 검색 반경 값 동적 구독 연동
+        viewModelScope.launch {
+            userPreferences.searchRadius.collect { radius ->
+                _searchRadius.value = radius
+            }
+        }
     }
 
     /**
@@ -179,10 +190,11 @@ class MapViewModel : ViewModel() {
         _isBottomSheetVisible.value = false
     }
 
-    // 카테고리 + 검색어를 함께 적용한 필터링 결과
+    // 카테고리 + 검색어 + 검색반경(거리단위)을 함께 적용한 필터링 결과
     fun getFilteredStores(): List<StoreItem> {
         val query = _searchQuery.value.trim()
         val category = _selectedCategory.value
+        val radius = _searchRadius.value
 
         return _nearbyStores.value.filter { store ->
             val matchCategory = category == MapCategory.ALL || store.category == category
@@ -190,7 +202,12 @@ class MapViewModel : ViewModel() {
                     store.name.contains(query, ignoreCase = true) ||
                     store.address.contains(query, ignoreCase = true) ||
                     store.tags.any { it.contains(query, ignoreCase = true) }
-            matchCategory && matchQuery
+            
+            // 키워드 검색 시 백엔드 API가 반경 설정을 무시하고 전역 매칭 결과를 반환하므로,
+            // 로컬 필터링 단에서 설정 반경(radius) 이내인 매장만 노출되도록 필터링을 추가 보완합니다.
+            val matchDistance = store.distanceMeters <= radius
+            
+            matchCategory && matchQuery && matchDistance
         }
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/navigation/NavGraph.kt
@@ -1,30 +1,151 @@
 package com.example.pickitpickit.ui.navigation
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.example.pickitpickit.ui.home.HomeScreen
 import com.example.pickitpickit.ui.mypage.MyPageScreen
+import com.example.pickitpickit.ui.store.StoreDetailScreen
+import com.example.pickitpickit.ui.store.StoreDetailUiState
+import com.example.pickitpickit.ui.store.StoreDetailViewModel
 
 @Composable
 fun MainNavGraph(
-    navController: NavHostController, 
+    navController: NavHostController,
     mapViewModel: com.example.pickitpickit.ui.map.MapViewModel,
     onLogoutClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // 현재 위치 값 (StoreDetailViewModel Factory에 전달)
+    val userLat by mapViewModel.userLatitude.collectAsState()
+    val userLng by mapViewModel.userLongitude.collectAsState()
+
     NavHost(
         navController = navController,
         startDestination = BottomNavMenuItem.Home.route,
         modifier = modifier
     ) {
         composable(BottomNavMenuItem.Home.route) {
-            HomeScreen(mapViewModel = mapViewModel)
+            HomeScreen(
+                mapViewModel = mapViewModel,
+                onStoreClick = { storeId ->
+                    navController.navigate("store_detail/$storeId")
+                }
+            )
         }
         composable(BottomNavMenuItem.MyPage.route) {
             MyPageScreen(onLogoutClick = onLogoutClick)
+        }
+        composable(
+            route = "store_detail/{storeId}",
+            arguments = listOf(navArgument("storeId") { type = NavType.IntType })
+        ) { backStackEntry ->
+            val storeId = backStackEntry.arguments?.getInt("storeId") ?: return@composable
+
+            // ViewModel은 백스택 엔트리 스코프로 생성 → 화면 재진입 시 자동 재활용
+            val storeDetailViewModel: StoreDetailViewModel = viewModel(
+                viewModelStoreOwner = backStackEntry,
+                factory = StoreDetailViewModel.Factory(
+                    storeId = storeId,
+                    userLatitude = userLat,
+                    userLongitude = userLng
+                )
+            )
+
+            val uiState by storeDetailViewModel.uiState.collectAsState()
+
+            when (val state = uiState) {
+                // ── 로딩 중 ────────────────────────────────────────────
+                is StoreDetailUiState.Loading -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color(0xFFF5F7FA)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            CircularProgressIndicator(color = Color(0xFF3B6EF8))
+                            Spacer(modifier = Modifier.height(14.dp))
+                            Text(
+                                "매장 정보를 불러오는 중이에요...",
+                                fontSize = 14.sp,
+                                color = Color(0xFF888888)
+                            )
+                        }
+                    }
+                }
+
+                // ── 에러 ───────────────────────────────────────────────
+                is StoreDetailUiState.Error -> {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(Color(0xFFF5F7FA)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier.padding(32.dp)
+                        ) {
+                            Text("😢", fontSize = 48.sp)
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+                                text = state.message,
+                                fontSize = 15.sp,
+                                color = Color(0xFF555555),
+                                textAlign = TextAlign.Center,
+                                lineHeight = 22.sp
+                            )
+                            Spacer(modifier = Modifier.height(24.dp))
+                            Button(
+                                onClick = { storeDetailViewModel.loadStoreDetail() },
+                                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF3B6EF8))
+                            ) {
+                                Text("다시 시도", fontWeight = FontWeight.Bold, color = Color.White)
+                            }
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Button(
+                                onClick = { navController.popBackStack() },
+                                colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFEEEEEE))
+                            ) {
+                                Text("돌아가기", fontWeight = FontWeight.Bold, color = Color(0xFF555555))
+                            }
+                        }
+                    }
+                }
+
+                // ── 성공 ───────────────────────────────────────────────
+                is StoreDetailUiState.Success -> {
+                    StoreDetailScreen(
+                        storeDetail = state.detail,
+                        onBackClick = { navController.popBackStack() }
+                    )
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailScreen.kt
@@ -1,0 +1,837 @@
+package com.example.pickitpickit.ui.store
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import com.example.pickitpickit.core.model.ProductDto
+import com.example.pickitpickit.core.model.StoreDetailDto
+import com.example.pickitpickit.core.model.StoreDetailResponse
+import com.example.pickitpickit.core.model.TagDto
+import com.example.pickitpickit.ui.theme.PickitPickitTheme
+
+// ──────────────────────────────────────────────────────────────
+// 매장 상세 화면
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+fun StoreDetailScreen(
+    storeDetail: StoreDetailResponse,
+    onBackClick: () -> Unit
+) {
+    val store = storeDetail.store
+
+    // 페이지네이션 상태 (상품 목록 페이지)
+    var currentPage by remember { mutableIntStateOf(1) }
+    val pageSize = 3
+    val totalPages = ((storeDetail.products.size - 1) / pageSize + 1).coerceAtLeast(1)
+    val pagedProducts = storeDetail.products
+        .drop((currentPage - 1) * pageSize)
+        .take(pageSize)
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF5F7FA)),
+        contentPadding = PaddingValues(bottom = 32.dp)
+    ) {
+        // ── 1. 헤더 이미지 + 뒤로 가기 ──────────────────────────
+        item {
+            StoreHeroSection(
+                storeName = store.name,
+                address = store.address ?: "주소 정보 없음",
+                imageUrl = store.mainImageUrl,
+                onBackClick = onBackClick
+            )
+        }
+
+        // ── 2. 통계 카드 4종 ────────────────────────────────────
+        item {
+            StoreStatCards(
+                totalStock = storeDetail.totalStockQuantity,
+                productCount = storeDetail.productCount,
+                nearExpiredCount = storeDetail.products.count {
+                    it.stockStatus == "NEAR_EMPTY" || it.stockStatus == "마감임박"
+                },
+                emptyCount = storeDetail.products.count {
+                    it.stockStatus == "EMPTY" || it.stockStatus == "품절"
+                }
+            )
+        }
+
+        // ── 3. 매장 정보 카드 ────────────────────────────────────
+        item {
+            StoreInfoCard(
+                hours = store.businessHours ?: "영업시간 정보 없음",
+                contact = store.contact ?: "전화번호 정보 없음",
+                avgDifficulty = if (storeDetail.products.isNotEmpty()) {
+                    storeDetail.products.map { it.difficulty }.average()
+                } else null,
+                kakaoMapUrl = store.kakaoDetailUrl
+            )
+        }
+
+        // ── 4. 상품 목록 헤더 ────────────────────────────────────
+        item {
+            ProductSectionHeader(totalCount = storeDetail.productCount)
+        }
+
+        // ── 5. 상품 아이템 목록 or 빈 상태 ──────────────────────
+        if (storeDetail.products.isEmpty()) {
+            item { ProductEmptyState() }
+        } else {
+            items(pagedProducts) { product ->
+                ProductListItem(product = product)
+            }
+
+            // ── 6. 페이지네이션 ──────────────────────────────────
+            if (totalPages > 1) {
+                item {
+                    Pagination(
+                        currentPage = currentPage,
+                        totalPages = totalPages,
+                        onPageClick = { currentPage = it }
+                    )
+                }
+            }
+        }
+
+        // ── 7. 팁 박스 ───────────────────────────────────────────
+        item {
+            TipBox()
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 헤어로 이미지 섹션
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun StoreHeroSection(
+    storeName: String,
+    address: String,
+    imageUrl: String?,
+    onBackClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(260.dp)
+    ) {
+        // 배경 이미지
+        if (!imageUrl.isNullOrEmpty()) {
+            AsyncImage(
+                model = imageUrl,
+                contentDescription = "매장 이미지",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(Color(0xFF7B3FBF), Color(0xFF4A2B8A), Color(0xFF1A1040))
+                        )
+                    )
+            )
+        }
+
+        // 상단 그라데이션 스크림 (뒤로 가기 버튼 가독성)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(100.dp)
+                .align(Alignment.TopCenter)
+                .background(
+                    Brush.verticalGradient(
+                        listOf(Color.Black.copy(alpha = 0.45f), Color.Transparent)
+                    )
+                )
+        )
+
+        // 하단 그라데이션 스크림 (텍스트 가독성)
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(130.dp)
+                .align(Alignment.BottomCenter)
+                .background(
+                    Brush.verticalGradient(
+                        listOf(Color.Transparent, Color.Black.copy(alpha = 0.7f))
+                    )
+                )
+        )
+
+        // 뒤로 가기 버튼
+        Row(
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .clickable { onBackClick() }
+                .align(Alignment.TopStart),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "뒤로 가기",
+                tint = Color.White,
+                modifier = Modifier.size(22.dp)
+            )
+            Spacer(modifier = Modifier.width(4.dp))
+            Text("뒤로 가기", color = Color.White, fontSize = 14.sp, fontWeight = FontWeight.Medium)
+        }
+
+        // 하단 매장명 + 주소
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(horizontal = 20.dp, vertical = 18.dp)
+        ) {
+            Text(
+                text = storeName,
+                fontWeight = FontWeight.ExtraBold,
+                fontSize = 22.sp,
+                color = Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.Default.LocationOn,
+                    contentDescription = null,
+                    tint = Color(0xFFFFCA28),
+                    modifier = Modifier.size(14.dp)
+                )
+                Spacer(modifier = Modifier.width(4.dp))
+                Text(
+                    text = address,
+                    fontSize = 12.sp,
+                    color = Color.White.copy(alpha = 0.9f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 통계 카드 2×2 그리드
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun StoreStatCards(
+    totalStock: Int,
+    productCount: Int,
+    nearExpiredCount: Int,
+    emptyCount: Int
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(top = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            StatCard(
+                label = "총 재고",
+                value = "$totalStock",
+                unit = "개",
+                gradient = Brush.linearGradient(listOf(Color(0xFF6B8AF7), Color(0xFF8B5CF6))),
+                modifier = Modifier.weight(1f)
+            )
+            StatCard(
+                label = "상품 종류",
+                value = "$productCount",
+                unit = "종",
+                gradient = Brush.linearGradient(listOf(Color(0xFFA78BFA), Color(0xFF7C3AED))),
+                modifier = Modifier.weight(1f)
+            )
+        }
+        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+            StatCard(
+                label = "마감임박",
+                value = "$nearExpiredCount",
+                unit = "개",
+                gradient = Brush.linearGradient(listOf(Color(0xFFF97316), Color(0xFFEF4444))),
+                modifier = Modifier.weight(1f)
+            )
+            StatCard(
+                label = "품절",
+                value = "$emptyCount",
+                unit = "개",
+                gradient = Brush.linearGradient(listOf(Color(0xFFFBBF24), Color(0xFFF97316))),
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun StatCard(
+    label: String,
+    value: String,
+    unit: String,
+    gradient: Brush,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .height(80.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(gradient)
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+    ) {
+        Column {
+            Text(label, color = Color.White.copy(alpha = 0.85f), fontSize = 12.sp, fontWeight = FontWeight.Medium)
+            Spacer(modifier = Modifier.height(4.dp))
+            Row(verticalAlignment = Alignment.Bottom) {
+                Text(value, color = Color.White, fontSize = 28.sp, fontWeight = FontWeight.ExtraBold, lineHeight = 32.sp)
+                Spacer(modifier = Modifier.width(3.dp))
+                Text(unit, color = Color.White.copy(alpha = 0.85f), fontSize = 12.sp, modifier = Modifier.padding(bottom = 4.dp))
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 매장 정보 카드
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun StoreInfoCard(
+    hours: String,
+    contact: String,
+    avgDifficulty: Double?,
+    kakaoMapUrl: String?
+) {
+    val difficultyLabel = when {
+        avgDifficulty == null -> "정보 없음"
+        avgDifficulty <= 1.5 -> "매우 쉬움 😊"
+        avgDifficulty <= 2.5 -> "보통 😊"
+        avgDifficulty <= 3.5 -> "보통 😐"
+        avgDifficulty <= 4.5 -> "어려움 😅"
+        else -> "극악 😱"
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 14.dp),
+        shape = RoundedCornerShape(18.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            // 헤더
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("📍", fontSize = 16.sp)
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "매장 정보",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 16.sp,
+                    color = Color(0xFF1A1A2E)
+                )
+            }
+
+            Spacer(modifier = Modifier.height(14.dp))
+            HorizontalDivider(color = Color(0xFFF0F0F0))
+            Spacer(modifier = Modifier.height(14.dp))
+
+            // 영업 시간
+            InfoRow(
+                icon = "🕐",
+                iconBgColor = Color(0xFFE8F5FF),
+                label = "영업 시간",
+                value = hours
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 전화번호
+            InfoRow(
+                icon = "📞",
+                iconBgColor = Color(0xFFE8FFE8),
+                label = "전화번호",
+                value = contact
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 평균 난이도
+            InfoRow(
+                icon = "🎯",
+                iconBgColor = Color(0xFFFFF3E0),
+                label = "평균 난이도",
+                value = difficultyLabel
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // 길찾기 버튼
+            Button(
+                onClick = { /* TODO: 카카오맵 아웃링크 */ },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(46.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = Color(0xFF3B6EF8)
+                )
+            ) {
+                Text("✈ ", fontSize = 14.sp, color = Color.White)
+                Text(
+                    "길찾기 (Google Maps)",
+                    fontWeight = FontWeight.SemiBold,
+                    fontSize = 14.sp,
+                    color = Color.White
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoRow(icon: String, iconBgColor: Color, label: String, value: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(CircleShape)
+                .background(iconBgColor),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(icon, fontSize = 16.sp)
+        }
+        Spacer(modifier = Modifier.width(12.dp))
+        Column {
+            Text(label, fontSize = 11.sp, color = Color(0xFF999999))
+            Text(value, fontSize = 14.sp, fontWeight = FontWeight.Medium, color = Color(0xFF1A1A2E))
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 상품 목록 섹션 헤더
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun ProductSectionHeader(totalCount: Int) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 4.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("🎁", fontSize = 20.sp)
+            Spacer(modifier = Modifier.width(6.dp))
+            Text(
+                "상품 목록",
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp,
+                color = Color(0xFF1A1A2E)
+            )
+        }
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(50.dp))
+                .background(Color(0xFF3B6EF8))
+                .padding(horizontal = 12.dp, vertical = 5.dp)
+        ) {
+            Text("${totalCount}개 상품", color = Color.White, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+        }
+    }
+
+    Text(
+        "상품을 클릭하면 상세 정보를 확인할 수 있어요!",
+        fontSize = 12.sp,
+        color = Color(0xFFAAAAAA),
+        modifier = Modifier.padding(horizontal = 16.dp).padding(bottom = 8.dp)
+    )
+}
+
+// ──────────────────────────────────────────────────────────────
+// 상품 아이템 카드
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun ProductListItem(product: ProductDto) {
+    val stockStatus = when (product.stockStatus?.uppercase()) {
+        "NEAR_EMPTY", "마감임박" -> "마감임박" to Color(0xFFEF4444)
+        "EMPTY", "품절" -> "품절" to Color(0xFF9E9E9E)
+        "PLENTY", "재고충분" -> "재고충분" to Color(0xFF22C55E)
+        else -> "보통" to Color(0xFF3B82F6)
+    }
+
+    val difficultyLabel = when {
+        product.difficulty <= 1 -> "쉬움" to Color(0xFF22C55E)
+        product.difficulty <= 2 -> "보통" to Color(0xFF3B82F6)
+        product.difficulty <= 3 -> "어려움" to Color(0xFFF97316)
+        else -> "극악" to Color(0xFFEF4444)
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 5.dp)
+            .clickable { /* TODO: 상품 상세 클릭 */ },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 상품 이미지
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(Color(0xFFEEEEEE))
+            ) {
+                if (!product.imageUrl.isNullOrEmpty()) {
+                    AsyncImage(
+                        model = product.imageUrl,
+                        contentDescription = product.itemName,
+                        modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(12.dp)),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+                // 재고 상태 뱃지
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .padding(4.dp)
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(stockStatus.second)
+                        .padding(horizontal = 5.dp, vertical = 2.dp)
+                ) {
+                    Text(stockStatus.first, color = Color.White, fontSize = 9.sp, fontWeight = FontWeight.Bold)
+                }
+            }
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            Column(modifier = Modifier.weight(1f)) {
+                // 상품명
+                Text(
+                    text = product.itemName,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 15.sp,
+                    color = Color(0xFF1A1A2E),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // 난이도 + 재고 + 가격
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Box(
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(6.dp))
+                            .background(difficultyLabel.second.copy(alpha = 0.12f))
+                            .padding(horizontal = 6.dp, vertical = 2.dp)
+                    ) {
+                        Text(
+                            difficultyLabel.first,
+                            color = difficultyLabel.second,
+                            fontSize = 11.sp,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                    }
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        "재고 ${product.stockQuantity}개",
+                        fontSize = 12.sp,
+                        color = Color(0xFF666666)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        "소형 ${product.price / 10000}만 ${product.price % 10000}원".let {
+                            if (product.price < 10000) "소형 ${product.price}원" else it
+                        },
+                        fontSize = 12.sp,
+                        color = Color(0xFF1A1A2E),
+                        fontWeight = FontWeight.Bold
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(6.dp))
+
+                // 태그
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    product.tags.take(3).forEach { tag ->
+                        Text(
+                            text = "#${tag.name}",
+                            fontSize = 11.sp,
+                            color = Color(0xFF3B6EF8),
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(Color(0xFFEEF3FF))
+                                .padding(horizontal = 6.dp, vertical = 2.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 페이지네이션
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun Pagination(currentPage: Int, totalPages: Int, onPageClick: (Int) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // 이전 버튼
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .clip(CircleShape)
+                .background(if (currentPage > 1) Color(0xFF3B6EF8) else Color(0xFFE0E0E0))
+                .clickable(enabled = currentPage > 1) { onPageClick(currentPage - 1) },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = "이전",
+                tint = Color.White,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+
+        Spacer(modifier = Modifier.width(8.dp))
+
+        // 페이지 번호들
+        val pagesToShow = (1..totalPages).toList().take(5)
+        pagesToShow.forEach { page ->
+            val isSelected = page == currentPage
+            Box(
+                modifier = Modifier
+                    .size(32.dp)
+                    .clip(CircleShape)
+                    .background(if (isSelected) Color(0xFF3B6EF8) else Color.White)
+                    .border(1.dp, if (isSelected) Color(0xFF3B6EF8) else Color(0xFFDDDDDD), CircleShape)
+                    .clickable { onPageClick(page) },
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    "$page",
+                    fontSize = 13.sp,
+                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Normal,
+                    color = if (isSelected) Color.White else Color(0xFF555555)
+                )
+            }
+            Spacer(modifier = Modifier.width(6.dp))
+        }
+
+        // 다음 버튼
+        Box(
+            modifier = Modifier
+                .size(32.dp)
+                .clip(CircleShape)
+                .background(if (currentPage < totalPages) Color(0xFF3B6EF8) else Color(0xFFE0E0E0))
+                .clickable(enabled = currentPage < totalPages) { onPageClick(currentPage + 1) },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = "다음",
+                tint = Color.White,
+                modifier = Modifier.size(18.dp)
+            )
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 상품 없음 빈 상태
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun ProductEmptyState() {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(18.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 36.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text("🎰", fontSize = 48.sp)
+            Spacer(modifier = Modifier.height(14.dp))
+            Text(
+                "아직 등록된 상품이 없어요",
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF333333)
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                "상품 정보가 곧 업데이트될 예정이에요!\n조금만 기다려 주세요 🙏",
+                fontSize = 13.sp,
+                color = Color(0xFF999999),
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                lineHeight = 20.sp
+            )
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 팁 박스
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun TipBox() {
+    val tips = listOf(
+        "상품 클릭으로 상세 정보를 확인하세요!",
+        "마감임박 상품은 3개 이하로 재고가 적으니 서두르세요!",
+        "난이도 쉬움 상품은 초보자도 쉽게 도전할 수 있어요!",
+        "재고는 실시간 업데이트되니 방문 전 꼭 확인하세요!"
+    )
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 10.dp),
+        shape = RoundedCornerShape(18.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFFFFDE7)),
+        border = CardDefaults.outlinedCardBorder().copy(width = 0.dp).let {
+            androidx.compose.foundation.BorderStroke(1.dp, Color(0xFFFFD600))
+        },
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("💡", fontSize = 18.sp)
+                Spacer(modifier = Modifier.width(6.dp))
+                Text("꿀팁!", fontWeight = FontWeight.Bold, fontSize = 15.sp, color = Color(0xFFB45309))
+            }
+            Spacer(modifier = Modifier.height(10.dp))
+            tips.forEach { tip ->
+                Row(modifier = Modifier.padding(vertical = 3.dp), verticalAlignment = Alignment.Top) {
+                    Text("✓ ", fontSize = 12.sp, color = Color(0xFF92400E), fontWeight = FontWeight.Bold)
+                    Text(tip, fontSize = 12.sp, color = Color(0xFF92400E), lineHeight = 18.sp)
+                }
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// Preview
+// ──────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, showSystemUi = true, name = "매장 상세 페이지")
+@Composable
+fun StoreDetailScreenPreview() {
+    PickitPickitTheme {
+        val dummyProducts = listOf(
+            ProductDto(
+                productId = 1L, itemId = 1L,
+                itemName = "산리오 헬로키티",
+                category = "인형",
+                price = 1000,
+                inventoryMode = "소형",
+                stockQuantity = 15,
+                stockStatus = "재고충분",
+                difficulty = 1,
+                difficultyLabel = "쉬움",
+                imageUrl = null,
+                tags = listOf(TagDto(1L, "산리오"), TagDto(2L, "헬로키티"), TagDto(3L, "인형"))
+            ),
+            ProductDto(
+                productId = 2L, itemId = 2L,
+                itemName = "뚱구 인형",
+                category = "인형",
+                price = 1000,
+                inventoryMode = "소형",
+                stockQuantity = 6,
+                stockStatus = "보통",
+                difficulty = 2,
+                difficultyLabel = "보통",
+                imageUrl = null,
+                tags = listOf(TagDto(1L, "뚱구"), TagDto(2L, "애니메이션"), TagDto(3L, "인형"))
+            ),
+            ProductDto(
+                productId = 3L, itemId = 3L,
+                itemName = "원피스 루피 피규어",
+                category = "피규어",
+                price = 1000,
+                inventoryMode = "대형",
+                stockQuantity = 13,
+                stockStatus = "마감임박",
+                difficulty = 4,
+                difficultyLabel = "극악",
+                imageUrl = null,
+                tags = listOf(TagDto(1L, "원피스"), TagDto(2L, "루피"), TagDto(3L, "피규어"))
+            )
+        )
+        val dummyStore = StoreDetailResponse(
+            store = StoreDetailDto(
+                id = 1L, sourcePlaceId = null,
+                name = "짱오락실 홍대점",
+                type = "CLAW",
+                latitude = 37.5565, longitude = 126.9235,
+                distance = 45,
+                address = "서울특별시 마포구 홍익로 45",
+                contact = "02-2345-6789",
+                businessHours = "09:00 - 23:00",
+                mainImageUrl = null,
+                kakaoDetailUrl = null
+            ),
+            productCount = 42,
+            totalStockQuantity = 384,
+            tags = listOf(TagDto(1L, "24시간"), TagDto(2L, "혜자샵")),
+            products = dummyProducts
+        )
+        StoreDetailScreen(storeDetail = dummyStore, onBackClick = {})
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailViewModel.kt
@@ -1,0 +1,80 @@
+package com.example.pickitpickit.ui.store
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.pickitpickit.core.model.StoreDetailResponse
+import com.example.pickitpickit.core.network.StoreRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+// ──────────────────────────────────────────────────────────────
+// UI 상태
+// ──────────────────────────────────────────────────────────────
+
+sealed class StoreDetailUiState {
+    object Loading : StoreDetailUiState()
+    data class Success(val detail: StoreDetailResponse) : StoreDetailUiState()
+    data class Error(val message: String) : StoreDetailUiState()
+}
+
+// ──────────────────────────────────────────────────────────────
+// ViewModel
+// ──────────────────────────────────────────────────────────────
+
+class StoreDetailViewModel(
+    private val storeId: Int,
+    private val userLatitude: Double? = null,
+    private val userLongitude: Double? = null
+) : ViewModel() {
+
+    private val repository = StoreRepository()
+
+    private val _uiState = MutableStateFlow<StoreDetailUiState>(StoreDetailUiState.Loading)
+    val uiState: StateFlow<StoreDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        loadStoreDetail()
+    }
+
+    fun loadStoreDetail() {
+        viewModelScope.launch {
+            _uiState.update { StoreDetailUiState.Loading }
+
+            Log.i("STORE_DETAIL_VM", "매장 상세 조회 시작: storeId=$storeId, lat=$userLatitude, lng=$userLongitude")
+
+            val detail = repository.getStoreDetail(
+                storeId = storeId.toLong(),
+                lat = userLatitude,
+                lng = userLongitude
+            )
+
+            if (detail != null) {
+                Log.i("STORE_DETAIL_VM", "매장 상세 조회 성공: ${detail.store.name}, 상품 ${detail.productCount}개")
+                _uiState.update { StoreDetailUiState.Success(detail) }
+            } else {
+                Log.e("STORE_DETAIL_VM", "매장 상세 조회 실패: storeId=$storeId")
+                _uiState.update { StoreDetailUiState.Error("매장 정보를 불러오지 못했어요.\n잠시 후 다시 시도해 주세요.") }
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // ViewModelProvider.Factory (storeId 주입을 위해 필요)
+    // ──────────────────────────────────────────────────────────────
+
+    class Factory(
+        private val storeId: Int,
+        private val userLatitude: Double? = null,
+        private val userLongitude: Double? = null
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return StoreDetailViewModel(storeId, userLatitude, userLongitude) as T
+        }
+    }
+}


### PR DESCRIPTION
- StoreDetailScreen: 헤어로 이미지, 통계 카드 2×2, 매장 정보,
  상품 목록/페이지네이션, 상품 미등록 Empty State UI 구현
- StoreDetailViewModel: getStoreDetail API 연동,
  Loading/Success/Error 상태 관리
- MapViewModel: userLatitude/userLongitude 공개 StateFlow 추가
- NavGraph: store_detail/{storeId} 라우트 추가,
  StoreDetailViewModel.Factory로 실제 API 연동
- HomeScreen: 매장 카드 클릭 시 상세 페이지 네비게이션 연결

Closes #22 