### PR TITLE
feat: 매장 상세 리뷰 CRUD 연동 및 검색 목록 실시간 데이터 매핑

### DIFF
--- a/app/src/main/java/com/example/pickitpickit/core/model/ReviewModels.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/model/ReviewModels.kt
@@ -1,0 +1,60 @@
+package com.example.pickitpickit.core.model
+
+// 개별 리뷰 DTO
+data class ReviewDto(
+    val reviewId: Long,
+    val userId: Long,
+    val authorNickname: String,
+    val authorProfileImageUrl: String?,
+    val storeId: Long,
+    val rating: Double,
+    val difficulty: Int,
+    val difficultyLabel: String?,
+    val content: String?,
+    val imageUrl: String?,
+    val createdAt: String,
+    val modifiedAt: String
+)
+
+// 매장 리뷰 목록 및 요약 응답 DTO
+data class StoreReviewListResponse(
+    val storeId: Long,
+    val reviewCount: Int,
+    val averageRating: Double,
+    val showRating: Boolean,
+    val averageDifficulty: Double,
+    val showDifficulty: Boolean,
+    val reviews: List<ReviewDto>
+)
+
+// 리뷰 작성 요청 Body
+data class ReviewRequest(
+    val userId: Long,
+    val storeId: Long,
+    val rating: Double,
+    val difficulty: Int,
+    val content: String?,
+    val imageUrl: String? = null
+)
+
+// 리뷰 수정(PATCH) 요청 Body
+data class ReviewPatchRequest(
+    val userId: Long,
+    val rating: Double,
+    val difficulty: Int,
+    val content: String?,
+    val imageUrl: String? = null
+)
+
+// 리뷰 가이드 세부 DTO
+data class GuideItemDto(
+    val title: String,
+    val messages: List<String>
+)
+
+// 리뷰 가이드 전체 응답 DTO
+data class ReviewWriteGuideResponse(
+    val reviewGuide: GuideItemDto,
+    val bragGuide: GuideItemDto
+)
+

--- a/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
@@ -4,6 +4,7 @@ import com.example.pickitpickit.core.network.api.AuthApi
 import com.example.pickitpickit.core.network.api.SearchApi
 import com.example.pickitpickit.core.network.api.OnboardingApi
 import com.example.pickitpickit.core.network.api.StoreApi
+import com.example.pickitpickit.core.network.api.ReviewApi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -64,4 +65,5 @@ object RetrofitClient {
     val searchApi: SearchApi by lazy { retrofit.create(SearchApi::class.java) }
     val onboardingApi: OnboardingApi by lazy { retrofit.create(OnboardingApi::class.java) }
     val storeApi: StoreApi by lazy { retrofit.create(StoreApi::class.java) }
+    val reviewApi: ReviewApi by lazy { retrofit.create(ReviewApi::class.java) }
 }

--- a/app/src/main/java/com/example/pickitpickit/core/network/ReviewRepository.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/ReviewRepository.kt
@@ -1,0 +1,125 @@
+package com.example.pickitpickit.core.network
+
+import android.util.Log
+import com.example.pickitpickit.core.model.ReviewRequest
+import com.example.pickitpickit.core.model.ReviewPatchRequest
+import com.example.pickitpickit.core.model.ReviewWriteGuideResponse
+import com.example.pickitpickit.core.model.StoreReviewListResponse
+
+class ReviewRepository {
+
+    suspend fun getStoreReviews(storeId: Long): StoreReviewListResponse? {
+        return try {
+            val response = RetrofitClient.reviewApi.getStoreReviews(storeId)
+            if (response.isSuccessful && response.body()?.success == true) {
+                val detail = response.body()!!.data
+                Log.i("REVIEW_REPO", "리뷰 조회 성공: storeId=$storeId, reviewsCount=${detail?.reviews?.size ?: 0}")
+                detail
+            } else {
+                Log.w("REVIEW_REPO", "리뷰 조회 실패: ${response.body()?.message}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("REVIEW_REPO", "리뷰 조회 네트워크 에러 storeId=$storeId", e)
+            null
+        }
+    }
+
+    suspend fun postReview(request: ReviewRequest): String? {
+        return try {
+            val response = RetrofitClient.reviewApi.postReview(request)
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("REVIEW_REPO", "리뷰 작성 성공: reviewId=${response.body()!!.data?.reviewId}")
+                null // null means success
+            } else {
+                val errorMsg = if (!response.isSuccessful) {
+                    val errorBodyStr = response.errorBody()?.string()
+                    try {
+                        val jsonObject = org.json.JSONObject(errorBodyStr ?: "")
+                        jsonObject.optString("message", "리뷰 등록에 실패했습니다.")
+                    } catch (e: Exception) {
+                        "리뷰 등록에 실패했습니다."
+                    }
+                } else {
+                    response.body()?.message ?: "리뷰 등록에 실패했습니다."
+                }
+                Log.w("REVIEW_REPO", "리뷰 작성 실패: $errorMsg")
+                errorMsg
+            }
+        } catch (e: Exception) {
+            Log.e("REVIEW_REPO", "리뷰 작성 네트워크 에러", e)
+            "네트워크 연결 상태를 확인해 주세요."
+        }
+    }
+
+    suspend fun updateReview(reviewId: Long, request: ReviewPatchRequest): String? {
+        return try {
+            val response = RetrofitClient.reviewApi.updateReview(reviewId, request)
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("REVIEW_REPO", "리뷰 수정 성공: reviewId=$reviewId")
+                null // null means success
+            } else {
+                val errorMsg = if (!response.isSuccessful) {
+                    val errorBodyStr = response.errorBody()?.string()
+                    try {
+                        val jsonObject = org.json.JSONObject(errorBodyStr ?: "")
+                        jsonObject.optString("message", "리뷰 수정에 실패했습니다.")
+                    } catch (e: Exception) {
+                        "리뷰 수정에 실패했습니다."
+                    }
+                } else {
+                    response.body()?.message ?: "리뷰 수정에 실패했습니다."
+                }
+                Log.w("REVIEW_REPO", "리뷰 수정 실패: $errorMsg")
+                errorMsg
+            }
+        } catch (e: Exception) {
+            Log.e("REVIEW_REPO", "리뷰 수정 네트워크 에러", e)
+            "네트워크 연결 상태를 확인해 주세요."
+        }
+    }
+
+    suspend fun deleteReview(reviewId: Long, userId: Long): String? {
+        return try {
+            val response = RetrofitClient.reviewApi.deleteReview(reviewId, userId)
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("REVIEW_REPO", "리뷰 삭제 성공: reviewId=$reviewId")
+                null // null means success
+            } else {
+                val errorMsg = if (!response.isSuccessful) {
+                    val errorBodyStr = response.errorBody()?.string()
+                    try {
+                        val jsonObject = org.json.JSONObject(errorBodyStr ?: "")
+                        jsonObject.optString("message", "리뷰 삭제에 실패했습니다.")
+                    } catch (e: Exception) {
+                        "리뷰 삭제에 실패했습니다."
+                    }
+                } else {
+                    response.body()?.message ?: "리뷰 삭제에 실패했습니다."
+                }
+                Log.w("REVIEW_REPO", "리뷰 삭제 실패: $errorMsg")
+                errorMsg
+            }
+        } catch (e: Exception) {
+            Log.e("REVIEW_REPO", "리뷰 삭제 네트워크 에러", e)
+            "네트워크 연결 상태를 확인해 주세요."
+        }
+    }
+
+    suspend fun getReviewWriteGuide(): ReviewWriteGuideResponse? {
+        return try {
+            val response = RetrofitClient.reviewApi.getReviewWriteGuide()
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("REVIEW_REPO", "리뷰 가이드 조회 성공")
+                response.body()!!.data
+            } else {
+                Log.w("REVIEW_REPO", "리뷰 가이드 조회 실패: ${response.body()?.message}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("REVIEW_REPO", "리뷰 가이드 조회 네트워크 에러", e)
+            null
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/pickitpickit/core/network/StoreRepository.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/StoreRepository.kt
@@ -3,6 +3,9 @@ package com.example.pickitpickit.core.network
 import android.util.Log
 import com.example.pickitpickit.ui.home.StoreItem
 import com.example.pickitpickit.ui.map.MapCategory
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 
 class StoreRepository {
 
@@ -32,34 +35,47 @@ class StoreRepository {
                 val dtoList = response.body()!!.data ?: emptyList()
                 Log.i("STORE_REPO", "주변 매장 조회 성공: ${dtoList.size}건 수신 (radius: ${radius}m)")
                 
-                dtoList.map { dto ->
-                    // DTO에서 StoreItem으로 매핑
-                    val mappedCategory = when (dto.type.uppercase()) {
-                        "CLAW" -> MapCategory.CLAW_MACHINE
-                        "GACHA" -> MapCategory.GACHA
-                        else -> MapCategory.MIXED
-                    }
+                val reviewRepository = ReviewRepository()
+                
+                coroutineScope {
+                    val deferredStores = dtoList.map { dto ->
+                        async {
+                            val mappedCategory = when (dto.type.uppercase()) {
+                                "CLAW" -> MapCategory.CLAW_MACHINE
+                                "GACHA" -> MapCategory.GACHA
+                                else -> MapCategory.MIXED
+                            }
 
-                    // 기본 태그 구성 (매장 타입에 부합하도록)
-                    val defaultTags = when (dto.type.uppercase()) {
-                        "CLAW" -> listOf("인형뽑기", "크레인게임")
-                        "GACHA" -> listOf("가챠", "캡슐토이", "피규어")
-                        else -> listOf("인형뽑기", "가챠", "종합샵")
-                    }
+                            // 1. 리뷰 데이터 비동기 조회 (실제 평점 및 리뷰 개수 연동)
+                            val reviewData = reviewRepository.getStoreReviews(dto.id.toLong())
+                            val realRating = reviewData?.averageRating?.toFloat() ?: 0.0f
+                            val realReviewCount = reviewData?.reviewCount ?: 0
 
-                    StoreItem(
-                        id = dto.id,
-                        name = dto.name,
-                        category = mappedCategory,
-                        rating = 4.5f, // API에 평점 정보 부재하므로 기본값
-                        reviewCount = 10, // API에 리뷰 개수 정보 부재하므로 기본값
-                        address = dto.address ?: "주소 정보 없음",
-                        hours = dto.businessHours ?: "영업시간 정보 없음",
-                        tags = defaultTags,
-                        distanceMeters = dto.distance,
-                        latitude = dto.latitude,
-                        longitude = dto.longitude
-                    )
+                            // 2. 매장 상세 정보 비동기 조회를 통해 실제 등록된 태그 수신
+                            val detailData = getStoreDetail(dto.id.toLong(), lat, lng)
+                            val realTags = detailData?.tags?.map { it.name } ?: when (dto.type.uppercase()) {
+                                "CLAW" -> listOf("인형뽑기", "크레인게임")
+                                "GACHA" -> listOf("가챠", "캡슐토이", "피규어")
+                                else -> listOf("인형뽑기", "가챠", "종합샵")
+                            }
+
+                            StoreItem(
+                                id = dto.id,
+                                name = dto.name,
+                                category = mappedCategory,
+                                rating = realRating,
+                                reviewCount = realReviewCount,
+                                address = dto.address ?: "주소 정보 없음",
+                                hours = dto.businessHours ?: "영업시간 정보 없음",
+                                tags = realTags,
+                                distanceMeters = dto.distance,
+                                latitude = dto.latitude,
+                                longitude = dto.longitude,
+                                mainImageUrl = dto.mainImageUrl
+                            )
+                        }
+                    }
+                    deferredStores.awaitAll()
                 }
             } else {
                 Log.w("STORE_REPO", "주변 매장 조회 실패: ${response.body()?.message}")
@@ -133,32 +149,47 @@ class StoreRepository {
                 val dtoList = response.body()!!.data ?: emptyList()
                 Log.i("STORE_REPO", "매장 검색 성공: ${dtoList.size}건 수신 (keyword: $keyword)")
 
-                dtoList.map { dto ->
-                    val mappedCategory = when (dto.type.uppercase()) {
-                        "CLAW" -> MapCategory.CLAW_MACHINE
-                        "GACHA" -> MapCategory.GACHA
-                        else -> MapCategory.MIXED
-                    }
+                val reviewRepository = ReviewRepository()
 
-                    val defaultTags = when (dto.type.uppercase()) {
-                        "CLAW" -> listOf("인형뽑기", "크레인게임")
-                        "GACHA" -> listOf("가챠", "캡슐토이", "피규어")
-                        else -> listOf("인형뽑기", "가챠", "종합샵")
-                    }
+                coroutineScope {
+                    val deferredStores = dtoList.map { dto ->
+                        async {
+                            val mappedCategory = when (dto.type.uppercase()) {
+                                "CLAW" -> MapCategory.CLAW_MACHINE
+                                "GACHA" -> MapCategory.GACHA
+                                else -> MapCategory.MIXED
+                            }
 
-                    StoreItem(
-                        id = dto.id,
-                        name = dto.name,
-                        category = mappedCategory,
-                        rating = 4.5f,
-                        reviewCount = 10,
-                        address = dto.address ?: "주소 정보 없음",
-                        hours = dto.businessHours ?: "영업시간 정보 없음",
-                        tags = defaultTags,
-                        distanceMeters = dto.distance,
-                        latitude = dto.latitude,
-                        longitude = dto.longitude
-                    )
+                            // 1. 리뷰 데이터 비동기 조회 (실제 평점 및 리뷰 개수 연동)
+                            val reviewData = reviewRepository.getStoreReviews(dto.id.toLong())
+                            val realRating = reviewData?.averageRating?.toFloat() ?: 0.0f
+                            val realReviewCount = reviewData?.reviewCount ?: 0
+
+                            // 2. 매장 상세 정보 비동기 조회를 통해 실제 등록된 태그 수신
+                            val detailData = getStoreDetail(dto.id.toLong(), lat, lng)
+                            val realTags = detailData?.tags?.map { it.name } ?: when (dto.type.uppercase()) {
+                                "CLAW" -> listOf("인형뽑기", "크레인게임")
+                                "GACHA" -> listOf("가챠", "캡슐토이", "피규어")
+                                else -> listOf("인형뽑기", "가챠", "종합샵")
+                            }
+
+                            StoreItem(
+                                id = dto.id,
+                                name = dto.name,
+                                category = mappedCategory,
+                                rating = realRating,
+                                reviewCount = realReviewCount,
+                                address = dto.address ?: "주소 정보 없음",
+                                hours = dto.businessHours ?: "영업시간 정보 없음",
+                                tags = realTags,
+                                distanceMeters = dto.distance,
+                                latitude = dto.latitude,
+                                longitude = dto.longitude,
+                                mainImageUrl = dto.mainImageUrl
+                            )
+                        }
+                    }
+                    deferredStores.awaitAll()
                 }
             } else {
                 Log.w("STORE_REPO", "매장 검색 실패: ${response.body()?.message}")

--- a/app/src/main/java/com/example/pickitpickit/core/network/api/ReviewApi.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/api/ReviewApi.kt
@@ -1,0 +1,65 @@
+package com.example.pickitpickit.core.network.api
+
+import com.example.pickitpickit.core.model.ApiResponse
+import com.example.pickitpickit.core.model.ReviewDto
+import com.example.pickitpickit.core.model.ReviewRequest
+import com.example.pickitpickit.core.model.ReviewPatchRequest
+import com.example.pickitpickit.core.model.ReviewWriteGuideResponse
+import com.example.pickitpickit.core.model.StoreReviewListResponse
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface ReviewApi {
+
+    /**
+     * 특정 매장의 리뷰 목록 및 요약 정보를 조회합니다.
+     * GET /api/reviews/stores/{storeId}
+     */
+    @GET("api/reviews/stores/{storeId}")
+    suspend fun getStoreReviews(
+        @Path("storeId") storeId: Long
+    ): Response<ApiResponse<StoreReviewListResponse>>
+
+    /**
+     * 특정 매장에 대한 리뷰를 작성합니다.
+     * POST /api/reviews
+     */
+    @POST("api/reviews")
+    suspend fun postReview(
+        @Body request: ReviewRequest
+    ): Response<ApiResponse<ReviewDto>>
+
+    /**
+     * 특정 리뷰를 수정합니다.
+     * PATCH /api/reviews/{reviewId}
+     */
+    @PATCH("api/reviews/{reviewId}")
+    suspend fun updateReview(
+        @Path("reviewId") reviewId: Long,
+        @Body request: ReviewPatchRequest
+    ): Response<ApiResponse<ReviewDto>>
+
+    /**
+     * 특정 리뷰를 삭제합니다.
+     * DELETE /api/reviews/{reviewId}?userId={userId}
+     */
+    @DELETE("api/reviews/{reviewId}")
+    suspend fun deleteReview(
+        @Path("reviewId") reviewId: Long,
+        @Query("userId") userId: Long
+    ): Response<ApiResponse<String>>
+
+    /**
+     * 리뷰 작성 가이드를 조회합니다.
+     * GET /api/reviews/write-guide
+     */
+    @GET("api/reviews/write-guide")
+    suspend fun getReviewWriteGuide(): Response<ApiResponse<ReviewWriteGuideResponse>>
+}
+

--- a/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
@@ -50,6 +50,8 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.example.pickitpickit.R
 import com.example.pickitpickit.ui.map.MapCategory
 import com.example.pickitpickit.ui.map.MapViewModel
+import coil.compose.AsyncImage
+import androidx.compose.ui.layout.ContentScale
 import com.google.android.gms.location.LocationServices
 import com.kakao.vectormap.KakaoMap
 import com.kakao.vectormap.KakaoMapReadyCallback
@@ -760,14 +762,23 @@ fun StoreListItem(
             modifier = Modifier.padding(12.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            // 썸네일 (더미)
+            // 썸네일
             Box(
                 modifier = Modifier
                     .size(72.dp)
                     .clip(RoundedCornerShape(8.dp))
-                    .background(Color(0xFFEEEEEE)),
+                    .background(Color(0xFFF3F4F6)),
                 contentAlignment = Alignment.TopStart
             ) {
+                if (!store.mainImageUrl.isNullOrEmpty()) {
+                    AsyncImage(
+                        model = store.mainImageUrl,
+                        contentDescription = "매장 썸네일",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+
                 // 카테고리 뱃지
                 Box(
                     modifier = Modifier

--- a/app/src/main/java/com/example/pickitpickit/ui/home/StoreItem.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/StoreItem.kt
@@ -13,7 +13,8 @@ data class StoreItem(
     val tags: List<String>,
     val distanceMeters: Int,
     val latitude: Double,
-    val longitude: Double
+    val longitude: Double,
+    val mainImageUrl: String? = null
 )
 
 // 더미 데이터 (백엔드 연동 전 UI 테스트용 및 미리보기 프리뷰용)

--- a/app/src/main/java/com/example/pickitpickit/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/navigation/NavGraph.kt
@@ -32,6 +32,7 @@ import com.example.pickitpickit.ui.mypage.MyPageScreen
 import com.example.pickitpickit.ui.store.StoreDetailScreen
 import com.example.pickitpickit.ui.store.StoreDetailUiState
 import com.example.pickitpickit.ui.store.StoreDetailViewModel
+import com.example.pickitpickit.ui.store.ReviewScreen
 
 @Composable
 fun MainNavGraph(
@@ -140,12 +141,47 @@ fun MainNavGraph(
 
                 // ── 성공 ───────────────────────────────────────────────
                 is StoreDetailUiState.Success -> {
+                    val isReviewSubmitting by storeDetailViewModel.isReviewSubmitting.collectAsState()
+                    val submitResult by storeDetailViewModel.submitResult.collectAsState(initial = null)
+                    val currentUserId by storeDetailViewModel.currentUserId.collectAsState()
+                    val writeGuide by storeDetailViewModel.writeGuide.collectAsState()
+
                     StoreDetailScreen(
                         storeDetail = state.detail,
-                        onBackClick = { navController.popBackStack() }
+                        reviewData = state.reviewData,
+                        onBackClick = { navController.popBackStack() },
+                        onSubmitReview = { rating, difficulty, content ->
+                            storeDetailViewModel.submitReview(rating, difficulty, content)
+                        },
+                        isReviewSubmitting = isReviewSubmitting,
+                        submitResult = submitResult,
+                        currentUserId = currentUserId,
+                        writeGuide = writeGuide,
+                        onEditReview = { reviewId, rating, difficulty, content ->
+                            storeDetailViewModel.editReview(reviewId, rating, difficulty, content)
+                        },
+                        onDeleteReview = { reviewId ->
+                            storeDetailViewModel.removeReview(reviewId)
+                        }
                     )
                 }
             }
+        }
+        composable(
+            route = "review/{storeId}?storeName={storeName}",
+            arguments = listOf(
+                navArgument("storeId") { type = NavType.LongType },
+                navArgument("storeName") { type = NavType.StringType; nullable = true }
+            )
+        ) { backStackEntry ->
+            val storeId = backStackEntry.arguments?.getLong("storeId") ?: return@composable
+            val storeName = backStackEntry.arguments?.getString("storeName") ?: "매장"
+
+            ReviewScreen(
+                storeId = storeId,
+                storeName = storeName,
+                onBackClick = { navController.popBackStack() }
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/store/ReviewScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/ReviewScreen.kt
@@ -1,0 +1,804 @@
+package com.example.pickitpickit.ui.store
+
+import android.widget.Toast
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.example.pickitpickit.core.model.ReviewDto
+import com.example.pickitpickit.core.model.StoreReviewListResponse
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ReviewScreen(
+    storeId: Long,
+    storeName: String,
+    onBackClick: () -> Unit
+) {
+    val viewModel: ReviewViewModel = viewModel(
+        factory = ReviewViewModel.Factory(storeId)
+    )
+
+    val reviewState by viewModel.reviewState.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val submitResult by viewModel.submitResult.collectAsState(initial = null)
+
+    var showWriteDialog by remember { mutableStateOf(false) }
+    val context = LocalContext.current
+
+    // 리뷰 작성 결과에 따른 다이얼로그 처리 및 토스트 메시지
+    LaunchedEffect(submitResult) {
+        submitResult?.let { result ->
+            if (result.isEmpty()) {
+                Toast.makeText(context, "리뷰가 성공적으로 등록되었습니다!", Toast.LENGTH_SHORT).show()
+                showWriteDialog = false
+            } else {
+                Toast.makeText(context, result, Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = "리뷰",
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1A2E)
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "뒤로 가기",
+                            tint = Color(0xFF1A1A2E)
+                        )
+                    }
+                },
+                actions = {
+                    // 우측 리뷰 작성 버튼
+                    Button(
+                        onClick = { showWriteDialog = true },
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFFFFB300) // 프리미엄 옐로우/오렌지
+                        ),
+                        shape = RoundedCornerShape(12.dp),
+                        contentPadding = PaddingValues(horizontal = 14.dp, vertical = 6.dp),
+                        modifier = Modifier.padding(end = 8.dp)
+                    ) {
+                        Text(
+                            text = "⭐ 리뷰 작성",
+                            fontSize = 13.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = Color(0xFF1A1A2E)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = Color.White
+                )
+            )
+        },
+        containerColor = Color(0xFFF5F7FA)
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+        ) {
+            if (isLoading && reviewState == null) {
+                // 첫 로딩 중
+                CircularProgressIndicator(
+                    color = Color(0xFF3B6EF8),
+                    modifier = Modifier.align(Alignment.Center)
+                )
+            } else {
+                val data = reviewState
+                if (data == null || data.reviews.isEmpty()) {
+                    // 빈 상태 UI
+                    ReviewEmptyState(
+                        storeName = storeName,
+                        onWriteClick = { showWriteDialog = true }
+                    )
+                } else {
+                    // 리뷰 목록
+                    ReviewListContent(
+                        data = data,
+                        onWriteClick = { showWriteDialog = true }
+                    )
+                }
+            }
+        }
+    }
+
+    // 리뷰 작성 모달 다이얼로그
+    if (showWriteDialog) {
+        ReviewWriteDialog(
+            storeName = storeName,
+            onDismiss = { showWriteDialog = false },
+            onSubmit = { rating, difficulty, content ->
+                viewModel.submitReview(rating, difficulty, content)
+            },
+            isSubmitting = isLoading
+        )
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 리뷰가 없을 때 빈 상태 UI
+// ──────────────────────────────────────────────────────────────
+@Composable
+private fun ReviewEmptyState(
+    storeName: String,
+    onWriteClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 24.dp),
+            shape = RoundedCornerShape(24.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 48.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                // 말풍선 아이콘 컨테이너
+                Box(
+                    modifier = Modifier
+                        .size(90.dp)
+                        .clip(CircleShape)
+                        .background(Color(0xFFEEF2FF)), // 부드러운 보라/블루 톤
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "💬",
+                        fontSize = 42.sp
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                Text(
+                    text = "아직 리뷰가 없어요",
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF1A1A2E)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Text(
+                    text = "첫 번째 리뷰를 남겨보세요!\n${storeName}에서의 경험을 공유해 주세요.",
+                    fontSize = 14.sp,
+                    color = Color(0xFF6B7280),
+                    textAlign = TextAlign.Center,
+                    lineHeight = 22.sp
+                )
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Button(
+                    onClick = onWriteClick,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = Color(0xFFFFB300)
+                    ),
+                    shape = RoundedCornerShape(14.dp),
+                    modifier = Modifier
+                        .fillMaxWidth(0.7f)
+                        .height(48.dp)
+                ) {
+                    Text(
+                        text = "⭐ 첫 리뷰 작성하기",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1A2E)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 리뷰가 존재할 때의 메인 목록 UI
+// ──────────────────────────────────────────────────────────────
+@Composable
+private fun ReviewListContent(
+    data: StoreReviewListResponse,
+    onWriteClick: () -> Unit
+) {
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(bottom = 32.dp)
+    ) {
+        // ── 1. 통계 헤더 (별점 요약 + 난이도 요약) ────────────────
+        item {
+            ReviewSummaryHeader(data = data)
+        }
+
+        // ── 2. 리뷰 수 타이틀 ────────────────────────────────────
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "방문자 리뷰",
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF1A1A2E)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color(0xFFE0E7FF))
+                        .padding(horizontal = 8.dp, vertical = 2.dp)
+                ) {
+                    Text(
+                        text = "${data.reviewCount}개",
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF3B6EF8)
+                    )
+                }
+            }
+        }
+
+        // ── 3. 리뷰 리스트 ───────────────────────────────────────
+        items(data.reviews) { review ->
+            ReviewItemCard(review = review)
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 리뷰 요약 헤더 (별점 및 난이도 그래프 등)
+// ──────────────────────────────────────────────────────────────
+@Composable
+private fun ReviewSummaryHeader(data: StoreReviewListResponse) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            // 별점 요약
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = "평균 별점",
+                    fontSize = 12.sp,
+                    color = Color(0xFF6B7280),
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = null,
+                        tint = Color(0xFFFFCA28),
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = String.format("%.1f", data.averageRating),
+                        fontSize = 26.sp,
+                        fontWeight = FontWeight.ExtraBold,
+                        color = Color(0xFF1A1A2E)
+                    )
+                }
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "총 ${data.reviewCount}개의 평가",
+                    fontSize = 11.sp,
+                    color = Color(0xFF9CA3AF)
+                )
+            }
+
+            // 구분선
+            Box(
+                modifier = Modifier
+                    .width(1.dp)
+                    .height(50.dp)
+                    .background(Color(0xFFE5E7EB))
+            )
+
+            // 난이도 요약
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = "체감 평균 난이도",
+                    fontSize = 12.sp,
+                    color = Color(0xFF6B7280),
+                    fontWeight = FontWeight.Medium
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                val diffLabel = when {
+                    data.averageDifficulty <= 1.5 -> "쉬움 😊"
+                    data.averageDifficulty <= 2.5 -> "보통 쉬움 🙂"
+                    data.averageDifficulty <= 3.5 -> "보통 😐"
+                    data.averageDifficulty <= 4.5 -> "어려움 😅"
+                    else -> "극악 😱"
+                }
+                Text(
+                    text = diffLabel,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF3B6EF8)
+                )
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = String.format("난이도 수치: %.1f", data.averageDifficulty),
+                    fontSize = 11.sp,
+                    color = Color(0xFF9CA3AF)
+                )
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 리뷰 개별 카드 UI
+// ──────────────────────────────────────────────────────────────
+@Composable
+private fun ReviewItemCard(review: ReviewDto) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            // 작성자 정보 및 별점
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                // 프로필 이미지
+                if (!review.authorProfileImageUrl.isNullOrEmpty()) {
+                    AsyncImage(
+                        model = review.authorProfileImageUrl,
+                        contentDescription = "프로필 이미지",
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    // 기본 아이콘
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape)
+                            .background(Color(0xFFF3F4F6)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("👤", fontSize = 16.sp)
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(10.dp))
+
+                // 닉네임 & 날짜
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = review.authorNickname,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1A2E)
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Text(
+                        text = review.createdAt.split("T").firstOrNull() ?: review.createdAt,
+                        fontSize = 11.sp,
+                        color = Color(0xFF9CA3AF)
+                    )
+                }
+
+                // 별점 표시
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = null,
+                        tint = Color(0xFFFFCA28),
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(3.dp))
+                    Text(
+                        text = String.format("%.1f", review.rating),
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1A2E)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 난이도 태그
+            review.difficultyLabel?.let { label ->
+                val tagColor = when (review.difficulty) {
+                    in 1..2 -> Color(0xFF10B981) // 쉬움 (초록)
+                    3 -> Color(0xFF3B82F6)      // 보통 (파랑)
+                    else -> Color(0xFFEF4444)    // 어려움 (빨강)
+                }
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(tagColor.copy(alpha = 0.1f))
+                        .padding(horizontal = 8.dp, vertical = 3.dp)
+                ) {
+                    Text(
+                        text = "난이도: $label",
+                        fontSize = 11.sp,
+                        fontWeight = FontWeight.SemiBold,
+                        color = tagColor
+                    )
+                }
+                Spacer(modifier = Modifier.height(10.dp))
+            }
+
+            // 리뷰 내용
+            if (!review.content.isNullOrEmpty()) {
+                Text(
+                    text = review.content,
+                    fontSize = 13.sp,
+                    color = Color(0xFF374151),
+                    lineHeight = 20.sp
+                )
+            }
+
+            // 첨부 이미지 (존재할 경우)
+            if (!review.imageUrl.isNullOrEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                AsyncImage(
+                    model = review.imageUrl,
+                    contentDescription = "리뷰 이미지",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(160.dp)
+                        .clip(RoundedCornerShape(12.dp)),
+                    contentScale = ContentScale.Crop
+                )
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 리뷰 작성 다이얼로그 모달
+// ──────────────────────────────────────────────────────────────
+@Composable
+fun ReviewWriteDialog(
+    storeName: String,
+    onDismiss: () -> Unit,
+    onSubmit: (rating: Double, difficulty: Int, content: String?) -> Unit,
+    isSubmitting: Boolean
+) {
+    var rating by remember { mutableDoubleStateOf(5.0) }
+    var difficulty by remember { mutableIntStateOf(3) } // 보통(3) 기본값
+    var content by remember { mutableStateOf("") }
+
+    val contentCharLimit = 200
+
+    Dialog(
+        onDismissRequest = { if (!isSubmitting) onDismiss() },
+        properties = DialogProperties(
+            dismissOnBackPress = !isSubmitting,
+            dismissOnClickOutside = !isSubmitting
+        )
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            shape = RoundedCornerShape(24.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(24.dp)
+                    .fillMaxWidth(),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                // X 닫기 버튼
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    IconButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        modifier = Modifier.align(Alignment.TopEnd)
+                    ) {
+                        Text("✕", fontSize = 16.sp, color = Color(0xFF9CA3AF))
+                    }
+                }
+
+                // 타이틀
+                Text(
+                    text = "⭐ 매장 리뷰 작성",
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF1A1A2E)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                // 서브타이틀
+                Text(
+                    text = buildString {
+                        append(storeName)
+                        append("을(를) 방문하셨나요?\n경험을 공유해 주세요!")
+                    },
+                    fontSize = 13.sp,
+                    color = Color(0xFF3B6EF8), // 파란색 강조색
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.Center,
+                    lineHeight = 18.sp
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // 1. 별점 선택
+                Text(
+                    text = "매장은 어떠셨나요?",
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF374151)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    for (i in 1..5) {
+                        val starRating = i.toDouble()
+                        val isSelected = starRating <= rating
+                        Icon(
+                            imageVector = Icons.Default.Star,
+                            contentDescription = "별점 $i",
+                            tint = if (isSelected) Color(0xFFFFCA28) else Color(0xFFE5E7EB),
+                            modifier = Modifier
+                                .size(36.dp)
+                                .clickable(enabled = !isSubmitting) {
+                                    rating = starRating
+                                }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // 2. 난이도 선택 (추가된 프리미엄 기능)
+                Text(
+                    text = "매장 인형뽑기/가챠 체감 난이도는?",
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF374151)
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    val difficulties = listOf(
+                        Triple(1, "쉬움 😊", Color(0xFF10B981)),
+                        Triple(3, "보통 😐", Color(0xFF3B82F6)),
+                        Triple(5, "어려움 😅", Color(0xFFEF4444))
+                    )
+
+                    difficulties.forEach { (value, label, color) ->
+                        val isSelected = difficulty == value
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(38.dp)
+                                .clip(RoundedCornerShape(10.dp))
+                                .background(
+                                    if (isSelected) color.copy(alpha = 0.15f) else Color(0xFFF3F4F6)
+                                )
+                                .border(
+                                    1.dp,
+                                    if (isSelected) color else Color.Transparent,
+                                    RoundedCornerShape(10.dp)
+                                )
+                                .clickable(enabled = !isSubmitting) {
+                                    difficulty = value
+                                },
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = label,
+                                fontSize = 12.sp,
+                                fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                                color = if (isSelected) color else Color(0xFF4B5563)
+                            )
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                // 3. 한 줄 평가 입력
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Text(
+                        text = "한 줄 평가 (선택사항)",
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF374151)
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                TextField(
+                    value = content,
+                    onValueChange = {
+                        if (it.length <= contentCharLimit) {
+                            content = it
+                        }
+                    },
+                    placeholder = {
+                        Text(
+                            text = "다른 사용자들에게 도움이 될 내용을 남겨주세요!",
+                            fontSize = 12.sp,
+                            color = Color(0xFF9CA3AF)
+                        )
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(100.dp)
+                        .clip(RoundedCornerShape(12.dp)),
+                    colors = TextFieldDefaults.colors(
+                        focusedContainerColor = Color(0xFFF9FAFB),
+                        unfocusedContainerColor = Color(0xFFF9FAFB),
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent
+                    ),
+                    textStyle = TextStyle(fontSize = 13.sp, color = Color(0xFF1F2937)),
+                    maxLines = 4,
+                    enabled = !isSubmitting
+                )
+
+                Spacer(modifier = Modifier.height(4.dp))
+
+                // 글자 수 표시
+                Text(
+                    text = "${content.length}/$contentCharLimit",
+                    fontSize = 11.sp,
+                    color = Color(0xFF9CA3AF),
+                    modifier = Modifier.align(Alignment.End)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                // 버튼들
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    // 취소 버튼
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(
+                            contentColor = Color(0xFF6B7280)
+                        ),
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(46.dp)
+                    ) {
+                        Text(
+                            text = "취소",
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+
+                    // 리뷰 등록 버튼
+                    Button(
+                        onClick = {
+                            onSubmit(rating, difficulty, content.ifBlank { null })
+                        },
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFFFFB300) // 오렌지/옐로우 강조색
+                        ),
+                        modifier = Modifier
+                            .weight(1.5f)
+                            .height(46.dp)
+                    ) {
+                        if (isSubmitting) {
+                            CircularProgressIndicator(
+                                color = Color(0xFF1A1A2E),
+                                modifier = Modifier.size(20.dp)
+                            )
+                        } else {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Text(
+                                    text = "✈ ",
+                                    fontSize = 14.sp,
+                                    color = Color(0xFF1A1A2E)
+                                )
+                                Text(
+                                    text = "리뷰 등록",
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = Color(0xFF1A1A2E)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/store/ReviewViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/ReviewViewModel.kt
@@ -1,0 +1,76 @@
+package com.example.pickitpickit.ui.store
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.pickitpickit.GlobalApplication
+import com.example.pickitpickit.core.model.ReviewRequest
+import com.example.pickitpickit.core.model.StoreReviewListResponse
+import com.example.pickitpickit.core.network.ReviewRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class ReviewViewModel(private val storeId: Long) : ViewModel() {
+
+    private val repository = ReviewRepository()
+
+    private val _reviewState = MutableStateFlow<StoreReviewListResponse?>(null)
+    val reviewState: StateFlow<StoreReviewListResponse?> = _reviewState.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _submitResult = MutableSharedFlow<String?>()
+    val submitResult: SharedFlow<String?> = _submitResult.asSharedFlow()
+
+    init {
+        loadReviews()
+    }
+
+    fun loadReviews() {
+        viewModelScope.launch {
+            _isLoading.update { true }
+            val response = repository.getStoreReviews(storeId)
+            _reviewState.update { response }
+            _isLoading.update { false }
+        }
+    }
+
+    fun submitReview(rating: Double, difficulty: Int, content: String?) {
+        viewModelScope.launch {
+            _isLoading.update { true }
+            val userId = GlobalApplication.userPreferences.getUserId().first() ?: 0L
+            val request = ReviewRequest(
+                userId = userId,
+                storeId = storeId,
+                rating = rating,
+                difficulty = difficulty,
+                content = content
+            )
+            val errorMsg = repository.postReview(request)
+            if (errorMsg == null) {
+                _submitResult.emit("")
+                // 작성 성공 시 목록 다시 로드
+                loadReviews()
+            } else {
+                _submitResult.emit(errorMsg)
+            }
+            _isLoading.update { false }
+        }
+    }
+
+    class Factory(private val storeId: Long) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return ReviewViewModel(storeId) as T
+        }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailScreen.kt
@@ -8,11 +8,18 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.animation.animateContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -22,15 +29,21 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import coil.compose.AsyncImage
 import com.example.pickitpickit.core.model.ProductDto
+import com.example.pickitpickit.core.model.ReviewDto
 import com.example.pickitpickit.core.model.StoreDetailDto
 import com.example.pickitpickit.core.model.StoreDetailResponse
+import com.example.pickitpickit.core.model.StoreReviewListResponse
 import com.example.pickitpickit.core.model.TagDto
 import com.example.pickitpickit.ui.theme.PickitPickitTheme
 
@@ -41,9 +54,34 @@ import com.example.pickitpickit.ui.theme.PickitPickitTheme
 @Composable
 fun StoreDetailScreen(
     storeDetail: StoreDetailResponse,
-    onBackClick: () -> Unit
+    reviewData: StoreReviewListResponse?,
+    onBackClick: () -> Unit,
+    onSubmitReview: (Double, Int, String?) -> Unit,
+    isReviewSubmitting: Boolean,
+    submitResult: String?,
+    currentUserId: Long?,
+    writeGuide: com.example.pickitpickit.core.model.ReviewWriteGuideResponse?,
+    onEditReview: (Long, Double, Int, String?) -> Unit,
+    onDeleteReview: (Long) -> Unit
 ) {
     val store = storeDetail.store
+    var showWriteDialog by remember { mutableStateOf(false) }
+    var editingReview by remember { mutableStateOf<ReviewDto?>(null) }
+    var reviewToDelete by remember { mutableStateOf<Long?>(null) }
+    val context = androidx.compose.ui.platform.LocalContext.current
+
+    LaunchedEffect(submitResult) {
+        submitResult?.let { result ->
+            if (result.isEmpty()) {
+                android.widget.Toast.makeText(context, "성공적으로 반영되었습니다!", android.widget.Toast.LENGTH_SHORT).show()
+                showWriteDialog = false
+                editingReview = null
+                reviewToDelete = null
+            } else {
+                android.widget.Toast.makeText(context, result, android.widget.Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
 
     // 페이지네이션 상태 (상품 목록 페이지)
     var currentPage by remember { mutableIntStateOf(1) }
@@ -124,6 +162,94 @@ fun StoreDetailScreen(
         item {
             TipBox()
         }
+
+        // ── 8. 리뷰 목록 헤더 ─────────────────────────────────────
+        item {
+            ReviewSectionHeader(
+                reviewCount = reviewData?.reviewCount ?: 0,
+                onWriteClick = { showWriteDialog = true }
+            )
+        }
+
+        // ── 9. 리뷰 리스트 or 빈 상태 ─────────────────────────────
+        if (reviewData == null || reviewData.reviews.isEmpty()) {
+            item {
+                ReviewEmptyCard()
+            }
+        } else {
+            items(reviewData.reviews) { review ->
+                ReviewListItemCard(
+                    review = review,
+                    currentUserId = currentUserId,
+                    onEditClick = { editingReview = review },
+                    onDeleteClick = { reviewToDelete = review.reviewId }
+                )
+            }
+        }
+    }
+
+    if (showWriteDialog || editingReview != null) {
+        StoreReviewWriteDialog(
+            storeName = store.name,
+            reviewToEdit = editingReview,
+            writeGuide = writeGuide,
+            onDismiss = {
+                showWriteDialog = false
+                editingReview = null
+            },
+            onSubmit = { rating, difficulty, content ->
+                if (editingReview != null) {
+                    onEditReview(editingReview!!.reviewId, rating, difficulty, content)
+                } else {
+                    onSubmitReview(rating, difficulty, content)
+                }
+            },
+            isSubmitting = isReviewSubmitting
+        )
+    }
+
+    if (reviewToDelete != null) {
+        AlertDialog(
+            onDismissRequest = { reviewToDelete = null },
+            title = {
+                Text(
+                    text = "리뷰 삭제",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                    color = Color(0xFF1A1A2E)
+                )
+            },
+            text = {
+                Text(
+                    text = "작성하신 리뷰를 정말로 삭제하시겠습니까?\n삭제된 리뷰는 복구할 수 없습니다.",
+                    fontSize = 14.sp,
+                    color = Color(0xFF4B5563)
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        reviewToDelete?.let { onDeleteReview(it) }
+                        reviewToDelete = null
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFEF4444)),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("삭제", color = Color.White)
+                }
+            },
+            dismissButton = {
+                OutlinedButton(
+                    onClick = { reviewToDelete = null },
+                    shape = RoundedCornerShape(8.dp),
+                    border = BorderStroke(1.dp, Color(0xFFD1D5DB))
+                ) {
+                    Text("취소", color = Color(0xFF4B5563))
+                }
+            },
+            containerColor = Color.White,
+            properties = DialogProperties(usePlatformDefaultWidth = true)
+        )
     }
 }
 
@@ -766,6 +892,635 @@ private fun TipBox() {
 }
 
 // ──────────────────────────────────────────────────────────────
+// 리뷰 요약 및 리스트 컴포넌트들
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun ReviewSectionHeader(
+    reviewCount: Int,
+    onWriteClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "⭐ 리뷰",
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp,
+                color = Color(0xFF1A1A2E)
+            )
+            Spacer(modifier = Modifier.width(6.dp))
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0xFFEEF2FF)) // 연한 보라/블루 톤
+                    .padding(horizontal = 8.dp, vertical = 2.dp)
+            ) {
+                Text(
+                    text = "${reviewCount}개",
+                    fontSize = 12.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF3B6EF8)
+                )
+            }
+        }
+
+        // 리뷰 작성 버튼 (프리미엄 노란색/오렌지 버튼)
+        Button(
+            onClick = onWriteClick,
+            colors = ButtonDefaults.buttonColors(
+                containerColor = Color(0xFFFFB300)
+            ),
+            shape = RoundedCornerShape(12.dp),
+            contentPadding = PaddingValues(horizontal = 14.dp, vertical = 6.dp)
+        ) {
+            Text(
+                text = "⭐ 리뷰 작성",
+                fontSize = 13.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF1A1A2E)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReviewEmptyCard() {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 48.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            // 말풍선 아이콘 컨테이너 (제공된 시안과 완벽한 일치)
+            Box(
+                modifier = Modifier
+                    .size(90.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFFEEF2FF)),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "💬",
+                    fontSize = 42.sp
+                )
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = "아직 리뷰가 없어요",
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF1A1A2E)
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Text(
+                text = "첫 번째 리뷰를 남겨보세요!",
+                fontSize = 13.sp,
+                color = Color(0xFF999999)
+            )
+        }
+    }
+}
+
+@Composable
+private fun ReviewListItemCard(
+    review: ReviewDto,
+    currentUserId: Long?,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            // 작성자 프로필 & 별점
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (!review.authorProfileImageUrl.isNullOrEmpty()) {
+                    AsyncImage(
+                        model = review.authorProfileImageUrl,
+                        contentDescription = "프로필 이미지",
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape)
+                            .background(Color(0xFFF3F4F6)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("👤", fontSize = 16.sp)
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(10.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = review.authorNickname,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1A2E)
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = review.createdAt.split("T").firstOrNull() ?: review.createdAt,
+                            fontSize = 11.sp,
+                            color = Color(0xFF9CA3AF)
+                        )
+                        if (review.userId == currentUserId) {
+                            Text(
+                                text = " • ",
+                                fontSize = 11.sp,
+                                color = Color(0xFF9CA3AF)
+                            )
+                            Text(
+                                text = "수정",
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color(0xFF6B7280),
+                                modifier = Modifier.clickable { onEditClick() }
+                            )
+                            Text(
+                                text = " | ",
+                                fontSize = 11.sp,
+                                color = Color(0xFFD1D5DB)
+                            )
+                            Text(
+                                text = "삭제",
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color(0xFFEF4444),
+                                modifier = Modifier.clickable { onDeleteClick() }
+                            )
+                        }
+                    }
+                }
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.Star,
+                        contentDescription = null,
+                        tint = Color(0xFFFFCA28),
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(3.dp))
+                    Text(
+                        text = String.format("%.1f", review.rating),
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1A2E)
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 난이도 태그
+            val tagColor = when (review.difficulty) {
+                in 1..2 -> Color(0xFF10B981) // 쉬움 (초록)
+                3 -> Color(0xFF3B82F6)      // 보통 (파랑)
+                else -> Color(0xFFEF4444)    // 어려움 (빨강)
+            }
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(6.dp))
+                    .background(tagColor.copy(alpha = 0.1f))
+                    .padding(horizontal = 8.dp, vertical = 3.dp)
+            ) {
+                Text(
+                    text = "난이도: ${review.difficultyLabel ?: "보통"}",
+                    fontSize = 11.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    color = tagColor
+                )
+            }
+
+            Spacer(modifier = Modifier.height(10.dp))
+
+            if (!review.content.isNullOrEmpty()) {
+                Text(
+                    text = review.content,
+                    fontSize = 13.sp,
+                    color = Color(0xFF374151),
+                    lineHeight = 20.sp
+                )
+            }
+
+            if (!review.imageUrl.isNullOrEmpty()) {
+                Spacer(modifier = Modifier.height(12.dp))
+                AsyncImage(
+                    model = review.imageUrl,
+                    contentDescription = "리뷰 이미지",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(160.dp)
+                        .clip(RoundedCornerShape(12.dp)),
+                    contentScale = ContentScale.Crop
+                )
+            }
+        }
+    }
+}
+
+
+@Composable
+private fun StoreReviewWriteDialog(
+    storeName: String,
+    reviewToEdit: ReviewDto? = null,
+    writeGuide: com.example.pickitpickit.core.model.ReviewWriteGuideResponse? = null,
+    onDismiss: () -> Unit,
+    onSubmit: (Double, Int, String?) -> Unit,
+    isSubmitting: Boolean
+) {
+    var rating by remember(reviewToEdit) { mutableDoubleStateOf(reviewToEdit?.rating ?: 5.0) }
+    var difficulty by remember(reviewToEdit) { mutableIntStateOf(reviewToEdit?.difficulty ?: 3) } // 보통 기본값
+    var content by remember(reviewToEdit) { mutableStateOf(reviewToEdit?.content ?: "") }
+    val contentCharLimit = 200
+
+    val scrollState = rememberScrollState()
+
+    Dialog(
+        onDismissRequest = { if (!isSubmitting) onDismiss() },
+        properties = DialogProperties(
+            dismissOnBackPress = !isSubmitting,
+            dismissOnClickOutside = !isSubmitting,
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth(0.92f)
+                .fillMaxHeight(0.85f)
+                .padding(vertical = 16.dp),
+            shape = RoundedCornerShape(24.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp)
+            ) {
+                // 상단 X 닫기 버튼 영역
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    IconButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        modifier = Modifier.align(Alignment.TopEnd)
+                    ) {
+                        Text("✕", fontSize = 16.sp, color = Color(0xFF9CA3AF))
+                    }
+                }
+
+                // 스크롤 가능한 본문 영역
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .verticalScroll(scrollState),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = if (reviewToEdit != null) "✏️ 매장 리뷰 수정" else "⭐ 매장 리뷰 작성",
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1A2E)
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Text(
+                        text = "${storeName}을(를) 방문하셨나요? 경험을 공유해주세요!",
+                        fontSize = 13.sp,
+                        color = Color(0xFF3B6EF8),
+                        fontWeight = FontWeight.SemiBold,
+                        textAlign = TextAlign.Center,
+                        lineHeight = 18.sp
+                    )
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    Text(
+                        text = "매장은 어떠셨나요?",
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF374151)
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        for (i in 1..5) {
+                            val starRating = i.toDouble()
+                            val isSelected = starRating <= rating
+                            Icon(
+                                imageVector = Icons.Default.Star,
+                                contentDescription = "별점 $i",
+                                tint = if (isSelected) Color(0xFFFFCA28) else Color(0xFFE5E7EB),
+                                modifier = Modifier
+                                    .size(36.dp)
+                                    .clickable(enabled = !isSubmitting) {
+                                        rating = starRating
+                                    }
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    Text(
+                        text = "매장 인형뽑기/가챠 체감 난이도는?",
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF374151)
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        val difficulties = listOf(
+                            Triple(1, "쉬움 😊", Color(0xFF10B981)),
+                            Triple(3, "보통 😐", Color(0xFF3B82F6)),
+                            Triple(5, "어려움 😅", Color(0xFFEF4444))
+                        )
+
+                        difficulties.forEach { (value, label, color) ->
+                            val isSelected = difficulty == value
+                            Box(
+                                modifier = Modifier
+                                    .weight(1f)
+                                    .height(38.dp)
+                                    .clip(RoundedCornerShape(10.dp))
+                                    .background(
+                                        if (isSelected) color.copy(alpha = 0.15f) else Color(0xFFF3F4F6)
+                                    )
+                                    .border(
+                                        1.dp,
+                                        if (isSelected) color else Color.Transparent,
+                                        RoundedCornerShape(10.dp)
+                                    )
+                                    .clickable(enabled = !isSubmitting) {
+                                        difficulty = value
+                                    },
+                                contentAlignment = Alignment.Center
+                            ) {
+                                Text(
+                                    text = label,
+                                    fontSize = 12.sp,
+                                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
+                                    color = if (isSelected) color else Color(0xFF4B5563)
+                                )
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    Text(
+                        text = "한 줄 평가 (선택사항)",
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF374151)
+                    )
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    TextField(
+                        value = content,
+                        onValueChange = {
+                            if (it.length <= contentCharLimit) {
+                                content = it
+                            }
+                        },
+                        placeholder = {
+                            Text(
+                                text = "다른 사용자들에게 도움이 될 내용을 남겨주세요!",
+                                fontSize = 12.sp,
+                                color = Color(0xFF9CA3AF)
+                            )
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(100.dp)
+                            .clip(RoundedCornerShape(12.dp)),
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color(0xFFF9FAFB),
+                            unfocusedContainerColor = Color(0xFFF9FAFB),
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        textStyle = TextStyle(fontSize = 13.sp, color = Color(0xFF1F2937)),
+                        maxLines = 4,
+                        enabled = !isSubmitting
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Text(
+                        text = "${content.length}/$contentCharLimit",
+                        fontSize = 11.sp,
+                        color = Color(0xFF9CA3AF),
+                        modifier = Modifier.align(Alignment.End)
+                    )
+
+                    // ── 💡 가이드 아코디언 카드 영역 ──────────────────
+                    if (writeGuide != null) {
+                        var isGuideExpanded by remember { mutableStateOf(false) }
+
+                        LaunchedEffect(isGuideExpanded) {
+                            if (isGuideExpanded) {
+                                // 레이아웃 확장 애니메이션(animateContentSize) 시간에 맞춰 부드럽게 하단 자동 스크롤
+                                kotlinx.coroutines.delay(150)
+                                scrollState.animateScrollTo(scrollState.maxValue)
+                            }
+                        }
+
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Card(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .animateContentSize(),
+                            shape = RoundedCornerShape(12.dp),
+                            colors = CardDefaults.cardColors(containerColor = Color(0xFFF9FAFB)),
+                            border = BorderStroke(1.dp, Color(0xFFE5E7EB))
+                        ) {
+                            Column(
+                                modifier = Modifier
+                                    .clickable { isGuideExpanded = !isGuideExpanded }
+                                    .padding(12.dp)
+                            ) {
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.SpaceBetween
+                                ) {
+                                    Row(verticalAlignment = Alignment.CenterVertically) {
+                                        Text(text = "💡", fontSize = 14.sp)
+                                        Spacer(modifier = Modifier.width(6.dp))
+                                        Text(
+                                            text = "리뷰 작성 가이드 꿀팁",
+                                            fontSize = 13.sp,
+                                            fontWeight = FontWeight.Bold,
+                                            color = Color(0xFF4B5563)
+                                        )
+                                    }
+                                    Icon(
+                                        imageVector = if (isGuideExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                                        contentDescription = null,
+                                        tint = Color(0xFF9CA3AF),
+                                        modifier = Modifier.size(18.dp)
+                                    )
+                                }
+
+                                if (isGuideExpanded) {
+                                    Spacer(modifier = Modifier.height(8.dp))
+                                    Spacer(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .height(1.dp)
+                                            .background(Color(0xFFE5E7EB))
+                                    )
+                                    Spacer(modifier = Modifier.height(8.dp))
+
+                                    // 후기 가이드
+                                    val reviewG = writeGuide.reviewGuide
+                                    Text(
+                                        text = "📝 ${reviewG.title}",
+                                        fontSize = 12.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        color = Color(0xFFFFB300)
+                                    )
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    reviewG.messages.forEach { msg ->
+                                        Text(
+                                            text = "• $msg",
+                                            fontSize = 11.sp,
+                                            color = Color(0xFF4B5563),
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(start = 6.dp, bottom = 2.dp),
+                                            textAlign = TextAlign.Start
+                                        )
+                                    }
+
+                                    Spacer(modifier = Modifier.height(10.dp))
+
+                                    // 자랑하기 가이드
+                                    val bragG = writeGuide.bragGuide
+                                    Text(
+                                        text = "📸 ${bragG.title}",
+                                        fontSize = 12.sp,
+                                        fontWeight = FontWeight.Bold,
+                                        color = Color(0xFFFFB300)
+                                    )
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    bragG.messages.forEach { msg ->
+                                        Text(
+                                            text = "• $msg",
+                                            fontSize = 11.sp,
+                                            color = Color(0xFF4B5563),
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(start = 6.dp, bottom = 2.dp),
+                                            textAlign = TextAlign.Start
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 하단 취소 / 등록 버튼 영역
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = Color(0xFF6B7280)),
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(46.dp)
+                    ) {
+                        Text("취소", fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                    }
+
+                    Button(
+                        onClick = {
+                            onSubmit(rating, difficulty, content.ifBlank { null })
+                        },
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFFB300)),
+                        modifier = Modifier
+                            .weight(1.5f)
+                            .height(46.dp)
+                    ) {
+                        if (isSubmitting) {
+                            CircularProgressIndicator(color = Color(0xFF1A1A2E), modifier = Modifier.size(20.dp))
+                        } else {
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                if (reviewToEdit != null) {
+                                    Text("✏️ ", fontSize = 14.sp, color = Color(0xFF1A1A2E))
+                                    Text("리뷰 수정", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color(0xFF1A1A2E))
+                                } else {
+                                    Text("✈ ", fontSize = 14.sp, color = Color(0xFF1A1A2E))
+                                    Text("리뷰 등록", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color(0xFF1A1A2E))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
 // Preview
 // ──────────────────────────────────────────────────────────────
 
@@ -832,6 +1587,17 @@ fun StoreDetailScreenPreview() {
             tags = listOf(TagDto(1L, "24시간"), TagDto(2L, "혜자샵")),
             products = dummyProducts
         )
-        StoreDetailScreen(storeDetail = dummyStore, onBackClick = {})
+        StoreDetailScreen(
+            storeDetail = dummyStore,
+            reviewData = null,
+            onBackClick = {},
+            onSubmitReview = { _, _, _ -> },
+            isReviewSubmitting = false,
+            submitResult = null,
+            currentUserId = null,
+            writeGuide = null,
+            onEditReview = { _, _, _, _ -> },
+            onDeleteReview = {}
+        )
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailViewModel.kt
@@ -4,11 +4,19 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.example.pickitpickit.GlobalApplication
+import com.example.pickitpickit.core.model.ReviewRequest
 import com.example.pickitpickit.core.model.StoreDetailResponse
+import com.example.pickitpickit.core.model.StoreReviewListResponse
+import com.example.pickitpickit.core.network.ReviewRepository
 import com.example.pickitpickit.core.network.StoreRepository
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -18,7 +26,10 @@ import kotlinx.coroutines.launch
 
 sealed class StoreDetailUiState {
     object Loading : StoreDetailUiState()
-    data class Success(val detail: StoreDetailResponse) : StoreDetailUiState()
+    data class Success(
+        val detail: StoreDetailResponse,
+        val reviewData: StoreReviewListResponse?
+    ) : StoreDetailUiState()
     data class Error(val message: String) : StoreDetailUiState()
 }
 
@@ -33,13 +44,46 @@ class StoreDetailViewModel(
 ) : ViewModel() {
 
     private val repository = StoreRepository()
+    private val reviewRepository = ReviewRepository()
 
     private val _uiState = MutableStateFlow<StoreDetailUiState>(StoreDetailUiState.Loading)
     val uiState: StateFlow<StoreDetailUiState> = _uiState.asStateFlow()
 
+    // 리뷰 작성 결과 흐름 (성공 시 "", 실패 시 구체적인 에러 메시지 전달)
+    private val _submitResult = MutableSharedFlow<String?>()
+    val submitResult: SharedFlow<String?> = _submitResult.asSharedFlow()
+
+    // 리뷰 작성 중 상태
+    private val _isReviewSubmitting = MutableStateFlow(false)
+    val isReviewSubmitting: StateFlow<Boolean> = _isReviewSubmitting.asStateFlow()
+
+    // 내 리뷰 식별을 위한 사용자 고유 ID 흐름
+    private val _currentUserId = MutableStateFlow<Long?>(null)
+    val currentUserId: StateFlow<Long?> = _currentUserId.asStateFlow()
+
+    // 리뷰 가이드 문구 흐름
+    private val _writeGuide = MutableStateFlow<com.example.pickitpickit.core.model.ReviewWriteGuideResponse?>(null)
+    val writeGuide: StateFlow<com.example.pickitpickit.core.model.ReviewWriteGuideResponse?> = _writeGuide.asStateFlow()
+
     init {
         loadStoreDetail()
+        loadCurrentUserId()
+        loadWriteGuide()
     }
+
+    private fun loadCurrentUserId() {
+        viewModelScope.launch {
+            _currentUserId.value = GlobalApplication.userPreferences.getUserId().first()
+        }
+    }
+
+    private fun loadWriteGuide() {
+        viewModelScope.launch {
+            val guide = reviewRepository.getReviewWriteGuide()
+            _writeGuide.update { guide }
+        }
+    }
+
 
     fun loadStoreDetail() {
         viewModelScope.launch {
@@ -47,21 +91,110 @@ class StoreDetailViewModel(
 
             Log.i("STORE_DETAIL_VM", "매장 상세 조회 시작: storeId=$storeId, lat=$userLatitude, lng=$userLongitude")
 
+            // 매장 상세 정보와 리뷰 정보 병렬/순차 조회
             val detail = repository.getStoreDetail(
                 storeId = storeId.toLong(),
                 lat = userLatitude,
                 lng = userLongitude
             )
 
+            val reviews = reviewRepository.getStoreReviews(storeId.toLong())
+
             if (detail != null) {
-                Log.i("STORE_DETAIL_VM", "매장 상세 조회 성공: ${detail.store.name}, 상품 ${detail.productCount}개")
-                _uiState.update { StoreDetailUiState.Success(detail) }
+                Log.i("STORE_DETAIL_VM", "매장 상세 및 리뷰 조회 성공: ${detail.store.name}, 상품 ${detail.productCount}개, 리뷰 ${reviews?.reviewCount ?: 0}개")
+                _uiState.update { StoreDetailUiState.Success(detail, reviews) }
             } else {
                 Log.e("STORE_DETAIL_VM", "매장 상세 조회 실패: storeId=$storeId")
                 _uiState.update { StoreDetailUiState.Error("매장 정보를 불러오지 못했어요.\n잠시 후 다시 시도해 주세요.") }
             }
         }
     }
+
+    fun submitReview(rating: Double, difficulty: Int, content: String?) {
+        viewModelScope.launch {
+            _isReviewSubmitting.update { true }
+            val userId = GlobalApplication.userPreferences.getUserId().first() ?: 0L
+            val request = ReviewRequest(
+                userId = userId,
+                storeId = storeId.toLong(),
+                rating = rating,
+                difficulty = difficulty,
+                content = content
+            )
+            val errorMsg = reviewRepository.postReview(request)
+            if (errorMsg == null) {
+                _submitResult.emit("")
+                // 작성 성공 시 상세 정보 및 리뷰 목록 다시 로드
+                val detail = repository.getStoreDetail(
+                    storeId = storeId.toLong(),
+                    lat = userLatitude,
+                    lng = userLongitude
+                )
+                val reviews = reviewRepository.getStoreReviews(storeId.toLong())
+                if (detail != null) {
+                    _uiState.update { StoreDetailUiState.Success(detail, reviews) }
+                }
+            } else {
+                _submitResult.emit(errorMsg)
+            }
+            _isReviewSubmitting.update { false }
+        }
+    }
+
+    fun editReview(reviewId: Long, rating: Double, difficulty: Int, content: String?) {
+        viewModelScope.launch {
+            _isReviewSubmitting.update { true }
+            val userId = _currentUserId.value ?: GlobalApplication.userPreferences.getUserId().first() ?: 0L
+            val request = com.example.pickitpickit.core.model.ReviewPatchRequest(
+                userId = userId,
+                rating = rating,
+                difficulty = difficulty,
+                content = content
+            )
+            val errorMsg = reviewRepository.updateReview(reviewId, request)
+            if (errorMsg == null) {
+                _submitResult.emit("")
+                // 수정 성공 시 상세 정보 및 리뷰 목록 다시 로드
+                val detail = repository.getStoreDetail(
+                    storeId = storeId.toLong(),
+                    lat = userLatitude,
+                    lng = userLongitude
+                )
+                val reviews = reviewRepository.getStoreReviews(storeId.toLong())
+                if (detail != null) {
+                    _uiState.update { StoreDetailUiState.Success(detail, reviews) }
+                }
+            } else {
+                _submitResult.emit(errorMsg)
+            }
+            _isReviewSubmitting.update { false }
+        }
+    }
+
+    fun removeReview(reviewId: Long) {
+        viewModelScope.launch {
+            _isReviewSubmitting.update { true }
+            val userId = _currentUserId.value ?: GlobalApplication.userPreferences.getUserId().first() ?: 0L
+            val errorMsg = reviewRepository.deleteReview(reviewId, userId)
+            if (errorMsg == null) {
+                _submitResult.emit("")
+                // 삭제 성공 시 상세 정보 및 리뷰 목록 다시 로드
+                val detail = repository.getStoreDetail(
+                    storeId = storeId.toLong(),
+                    lat = userLatitude,
+                    lng = userLongitude
+                )
+                val reviews = reviewRepository.getStoreReviews(storeId.toLong())
+                if (detail != null) {
+                    _uiState.update { StoreDetailUiState.Success(detail, reviews) }
+                }
+            } else {
+                _submitResult.emit(errorMsg)
+            }
+            _isReviewSubmitting.update { false }
+        }
+    }
+
 
     // ──────────────────────────────────────────────────────────────
     // ViewModelProvider.Factory (storeId 주입을 위해 필요)


### PR DESCRIPTION
- 매장 상세 스크롤 하단에 리뷰 섹션(목록 조회/등록/수정/삭제) 통합 구현
- 중복 작성(1인 1개 제한) 시 409 에러 메시지 Toast 자동 대응 구현
- 리뷰 작성 꿀팁 가이드(GET) 및 토글 시 부드러운 자동 하단 스크롤 적용
- 홈/검색 목록에 실시간 평점, 리뷰 개수, 실제 태그 및 이미지(Coil) 병렬 결합 연동