### PR TITLE
feat: 자랑하기 UI 개선, 수정 기능 추가 및 갤러리 이미지 로드 에러 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <application
         android:name=".GlobalApplication"
@@ -44,6 +45,16 @@
                 <data android:host="oauth" android:scheme="kakao4597cdb7fc04bfb5aca3e2f07d375aa7" />
             </intent-filter>
         </activity>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/pickitpickit/core/model/BragModels.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/model/BragModels.kt
@@ -1,0 +1,50 @@
+package com.example.pickitpickit.core.model
+
+/**
+ * 개별 자랑글 DTO
+ */
+data class BragDto(
+    val bragId: Long,
+    val userId: Long,
+    val authorNickname: String,
+    val authorProfileImageUrl: String?,
+    val storeId: Long,
+    val spentCost: Int,
+    val imageUrl: String,
+    val content: String,
+    val createdAt: String,
+    val modifiedAt: String
+)
+
+/**
+ * 매장 자랑글 목록 응답 DTO (추정)
+ */
+data class StoreBragListResponse(
+    val storeId: Long,
+    val bragCount: Int,
+    val brags: List<BragDto>
+)
+
+/**
+ * 자랑글 등록 요청 Body
+ * POST /api/reviews/brags
+ */
+data class BragRequest(
+    val userId: Long,
+    val storeId: Long,
+    val spentCost: Int,
+    val imageUrl: String,
+    val content: String
+)
+
+/**
+ * 자랑글 수정 요청 Body
+ * PATCH /api/reviews/brags/{bragId}
+ */
+data class BragPatchRequest(
+    val userId: Long,
+    val storeId: Long,
+    val spentCost: Int,
+    val imageUrl: String,
+    val content: String
+)

--- a/app/src/main/java/com/example/pickitpickit/core/network/BragRepository.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/BragRepository.kt
@@ -1,0 +1,107 @@
+package com.example.pickitpickit.core.network
+
+import android.util.Log
+import com.example.pickitpickit.core.model.BragDto
+import com.example.pickitpickit.core.model.BragRequest
+import com.example.pickitpickit.core.model.BragPatchRequest
+
+class BragRepository {
+
+    suspend fun postBrag(request: BragRequest): String? {
+        return try {
+            val response = RetrofitClient.bragApi.postBrag(request)
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("BRAG_REPO", "자랑글 작성 성공: bragId=${response.body()!!.data?.bragId}")
+                null // null means success
+            } else {
+                val errorMsg = if (!response.isSuccessful) {
+                    val errorBodyStr = response.errorBody()?.string()
+                    try {
+                        val jsonObject = org.json.JSONObject(errorBodyStr ?: "")
+                        jsonObject.optString("message", "자랑글 등록에 실패했습니다.")
+                    } catch (e: Exception) {
+                        "자랑글 등록에 실패했습니다."
+                    }
+                } else {
+                    response.body()?.message ?: "자랑글 등록에 실패했습니다."
+                }
+                Log.w("BRAG_REPO", "자랑글 작성 실패: $errorMsg")
+                errorMsg
+            }
+        } catch (e: Exception) {
+            Log.e("BRAG_REPO", "자랑글 작성 네트워크 에러", e)
+            "네트워크 연결 상태를 확인해 주세요."
+        }
+    }
+
+    suspend fun updateBrag(bragId: Long, request: BragPatchRequest): String? {
+        return try {
+            val response = RetrofitClient.bragApi.updateBrag(bragId, request)
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("BRAG_REPO", "자랑글 수정 성공: bragId=$bragId")
+                null // null means success
+            } else {
+                val errorMsg = if (!response.isSuccessful) {
+                    val errorBodyStr = response.errorBody()?.string()
+                    try {
+                        val jsonObject = org.json.JSONObject(errorBodyStr ?: "")
+                        jsonObject.optString("message", "자랑글 수정에 실패했습니다.")
+                    } catch (e: Exception) {
+                        "자랑글 수정에 실패했습니다."
+                    }
+                } else {
+                    response.body()?.message ?: "자랑글 수정에 실패했습니다."
+                }
+                Log.w("BRAG_REPO", "자랑글 수정 실패: $errorMsg")
+                errorMsg
+            }
+        } catch (e: Exception) {
+            Log.e("BRAG_REPO", "자랑글 수정 네트워크 에러", e)
+            "네트워크 연결 상태를 확인해 주세요."
+        }
+    }
+
+    suspend fun deleteBrag(bragId: Long, userId: Long): String? {
+        return try {
+            val response = RetrofitClient.bragApi.deleteBrag(bragId, userId)
+            if (response.isSuccessful && response.body()?.success == true) {
+                Log.i("BRAG_REPO", "자랑글 삭제 성공: bragId=$bragId")
+                null // null means success
+            } else {
+                val errorMsg = if (!response.isSuccessful) {
+                    val errorBodyStr = response.errorBody()?.string()
+                    try {
+                        val jsonObject = org.json.JSONObject(errorBodyStr ?: "")
+                        jsonObject.optString("message", "자랑글 삭제에 실패했습니다.")
+                    } catch (e: Exception) {
+                        "자랑글 삭제에 실패했습니다."
+                    }
+                } else {
+                    response.body()?.message ?: "자랑글 삭제에 실패했습니다."
+                }
+                Log.w("BRAG_REPO", "자랑글 삭제 실패: $errorMsg")
+                errorMsg
+            }
+        } catch (e: Exception) {
+            Log.e("BRAG_REPO", "자랑글 삭제 네트워크 에러", e)
+            "네트워크 연결 상태를 확인해 주세요."
+        }
+    }
+
+    suspend fun getAllBrags(): List<BragDto>? {
+        return try {
+            val response = RetrofitClient.bragApi.getAllBrags()
+            if (response.isSuccessful && response.body()?.success == true) {
+                val detail = response.body()!!.data
+                Log.i("BRAG_REPO", "전체 자랑글 조회 성공: count=${detail?.size ?: 0}")
+                detail
+            } else {
+                Log.w("BRAG_REPO", "전체 자랑글 조회 실패: ${response.body()?.message}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("BRAG_REPO", "전체 자랑글 조회 네트워크 에러", e)
+            null
+        }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/RetrofitClient.kt
@@ -6,6 +6,7 @@ import com.example.pickitpickit.core.network.api.OnboardingApi
 import com.example.pickitpickit.core.network.api.StoreApi
 import com.example.pickitpickit.core.network.api.ReviewApi
 import com.example.pickitpickit.core.network.api.UserApi
+import com.example.pickitpickit.core.network.api.BragApi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -68,4 +69,5 @@ object RetrofitClient {
     val storeApi: StoreApi by lazy { retrofit.create(StoreApi::class.java) }
     val reviewApi: ReviewApi by lazy { retrofit.create(ReviewApi::class.java) }
     val userApi: UserApi by lazy { retrofit.create(UserApi::class.java) }
+    val bragApi: BragApi by lazy { retrofit.create(BragApi::class.java) }
 }

--- a/app/src/main/java/com/example/pickitpickit/core/network/api/BragApi.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/api/BragApi.kt
@@ -1,0 +1,53 @@
+package com.example.pickitpickit.core.network.api
+
+import com.example.pickitpickit.core.model.ApiResponse
+import com.example.pickitpickit.core.model.BragDto
+import com.example.pickitpickit.core.model.BragRequest
+import com.example.pickitpickit.core.model.BragPatchRequest
+import retrofit2.Response
+import retrofit2.http.Body
+import retrofit2.http.DELETE
+import retrofit2.http.GET
+import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface BragApi {
+
+    /**
+     * 인형뽑기 결과물 자랑 게시글을 작성합니다.
+     * POST /api/reviews/brags
+     */
+    @POST("api/reviews/brags")
+    suspend fun postBrag(
+        @Body request: BragRequest
+    ): Response<ApiResponse<BragDto>>
+
+    /**
+     * 자랑하기 게시글을 수정합니다.
+     * PATCH /api/reviews/brags/{bragId}
+     */
+    @PATCH("api/reviews/brags/{bragId}")
+    suspend fun updateBrag(
+        @Path("bragId") bragId: Long,
+        @Body request: BragPatchRequest
+    ): Response<ApiResponse<BragDto>>
+
+    /**
+     * 자랑하기 게시글을 삭제합니다.
+     * DELETE /api/reviews/brags/{bragId}?userId={userId}
+     */
+    @DELETE("api/reviews/brags/{bragId}")
+    suspend fun deleteBrag(
+        @Path("bragId") bragId: Long,
+        @Query("userId") userId: Long
+    ): Response<ApiResponse<String>>
+
+    /**
+     * 전체 자랑하기 게시글 목록을 조회합니다.
+     * GET /api/reviews/brags
+     */
+    @GET("api/reviews/brags")
+    suspend fun getAllBrags(): Response<ApiResponse<List<BragDto>>>
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/navigation/NavGraph.kt
@@ -142,12 +142,14 @@ fun MainNavGraph(
                 // ── 성공 ───────────────────────────────────────────────
                 is StoreDetailUiState.Success -> {
                     val isReviewSubmitting by storeDetailViewModel.isReviewSubmitting.collectAsState()
+                    val isBragSubmitting by storeDetailViewModel.isBragSubmitting.collectAsState()
                     val currentUserId by storeDetailViewModel.currentUserId.collectAsState()
                     val writeGuide by storeDetailViewModel.writeGuide.collectAsState()
 
                     StoreDetailScreen(
                         storeDetail = state.detail,
                         reviewData = state.reviewData,
+                        bragData = state.bragData,
                         onBackClick = { navController.popBackStack() },
                         onSubmitReview = { rating, difficulty, content ->
                             storeDetailViewModel.submitReview(rating, difficulty, content)
@@ -161,6 +163,17 @@ fun MainNavGraph(
                         },
                         onDeleteReview = { reviewId ->
                             storeDetailViewModel.removeReview(reviewId)
+                        },
+                        isBragSubmitting = isBragSubmitting,
+                        bragSubmitResultFlow = storeDetailViewModel.bragSubmitResult,
+                        onSubmitBrag = { spentCost, imageUrl, content ->
+                            storeDetailViewModel.submitBrag(spentCost, imageUrl, content)
+                        },
+                        onDeleteBrag = { bragId ->
+                            storeDetailViewModel.removeBrag(bragId)
+                        },
+                        onEditBrag = { bragId, spentCost, imageUrl, content ->
+                            storeDetailViewModel.editBrag(bragId, spentCost, imageUrl, content)
                         }
                     )
                 }

--- a/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailScreen.kt
@@ -16,10 +16,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.automirrored.filled.Send
 import androidx.compose.material.icons.filled.LocationOn
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -47,6 +49,28 @@ import com.example.pickitpickit.core.model.StoreReviewListResponse
 import com.example.pickitpickit.core.model.TagDto
 import com.example.pickitpickit.ui.theme.PickitPickitTheme
 import kotlinx.coroutines.flow.SharedFlow
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.res.painterResource
+import androidx.activity.compose.rememberLauncherForActivityResult
+import android.util.Log
+
+data class BragItem(
+    val id: Long,
+    val title: String,
+    val description: String?,
+    val storeName: String?,
+    val imageUrl: String,
+    val tags: List<String>,
+    val authorNickname: String,
+    val authorProfileImageUrl: String?,
+    val createdAt: String
+)
 
 // ──────────────────────────────────────────────────────────────
 // 매장 상세 화면
@@ -56,6 +80,7 @@ import kotlinx.coroutines.flow.SharedFlow
 fun StoreDetailScreen(
     storeDetail: StoreDetailResponse,
     reviewData: StoreReviewListResponse?,
+    bragData: List<com.example.pickitpickit.core.model.BragDto>?,
     onBackClick: () -> Unit,
     onSubmitReview: (Double, Int, String?) -> Unit,
     isReviewSubmitting: Boolean,
@@ -63,13 +88,24 @@ fun StoreDetailScreen(
     currentUserId: Long?,
     writeGuide: com.example.pickitpickit.core.model.ReviewWriteGuideResponse?,
     onEditReview: (Long, Double, Int, String?) -> Unit,
-    onDeleteReview: (Long) -> Unit
+    onDeleteReview: (Long) -> Unit,
+    isBragSubmitting: Boolean,
+    bragSubmitResultFlow: SharedFlow<String?>,
+    onSubmitBrag: (Int, String, String) -> Unit,
+    onDeleteBrag: (Long) -> Unit,
+    onEditBrag: (Long, Int, String, String) -> Unit
 ) {
     val store = storeDetail.store
     var showWriteDialog by remember { mutableStateOf(false) }
     var editingReview by remember { mutableStateOf<ReviewDto?>(null) }
     var reviewToDelete by remember { mutableStateOf<Long?>(null) }
     val context = androidx.compose.ui.platform.LocalContext.current
+
+    // 자랑하기 팝업 및 삭제 상태 관리
+    var showBragWriteDialog by remember { mutableStateOf(false) }
+    var bragToDelete by remember { mutableStateOf<Long?>(null) }
+    var zoomedImageUri by remember { mutableStateOf<String?>(null) }
+    var editingBrag by remember { mutableStateOf<com.example.pickitpickit.core.model.BragDto?>(null) }
 
     LaunchedEffect(Unit) {
         submitResultFlow.collect { result ->
@@ -95,6 +131,32 @@ fun StoreDetailScreen(
                     }
                     else -> {
                         // 에러 메시지
+                        android.widget.Toast.makeText(context, msg, android.widget.Toast.LENGTH_SHORT).show()
+                    }
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        bragSubmitResultFlow.collect { result ->
+            result?.let { msg ->
+                when (msg) {
+                    "CREATE_SUCCESS", "" -> {
+                        android.widget.Toast.makeText(context, "자랑글이 성공적으로 등록되었습니다!", android.widget.Toast.LENGTH_SHORT).show()
+                        showBragWriteDialog = false
+                        bragToDelete = null
+                    }
+                    "DELETE_SUCCESS" -> {
+                        android.widget.Toast.makeText(context, "자랑글이 성공적으로 삭제되었습니다!", android.widget.Toast.LENGTH_SHORT).show()
+                        bragToDelete = null
+                    }
+                    "EDIT_SUCCESS" -> {
+                        showBragWriteDialog = false
+                        editingBrag = null
+                        bragToDelete = null
+                    }
+                    else -> {
                         android.widget.Toast.makeText(context, msg, android.widget.Toast.LENGTH_SHORT).show()
                     }
                 }
@@ -208,6 +270,37 @@ fun StoreDetailScreen(
                 )
             }
         }
+
+        // ── 10. 자랑하기 섹션 헤더 ──────────────────────────────────
+        item {
+            BragSectionHeader(
+                bragCount = bragData?.size ?: 0,
+                onWriteClick = { showBragWriteDialog = true }
+            )
+        }
+
+        // ── 11. 자랑하기 리스트 or 빈 상태 ───────────────────────────
+        if (bragData.isNullOrEmpty()) {
+            item {
+                BragEmptyCard(
+                    onWriteClick = { showBragWriteDialog = true }
+                )
+            }
+        } else {
+            items(bragData) { brag ->
+                BragListItemCard(
+                    brag = brag,
+                    currentUserId = currentUserId,
+                    onDeleteClick = {
+                        bragToDelete = brag.bragId
+                    },
+                    onEditClick = {
+                        editingBrag = brag
+                    },
+                    onImageClick = { zoomedImageUri = it }
+                )
+            }
+        }
     }
 
     if (showWriteDialog || editingReview != null) {
@@ -229,6 +322,27 @@ fun StoreDetailScreen(
                 }
             },
             isSubmitting = isReviewSubmitting
+        )
+    }
+
+    if (showBragWriteDialog || editingBrag != null) {
+        StoreBragWriteDialog(
+            storeName = store.name,
+            bragToEdit = editingBrag,
+            onDismiss = {
+                showBragWriteDialog = false
+                editingBrag = null
+            },
+            onSubmit = { imageUri, content ->
+                if (editingBrag != null) {
+                    onEditBrag(editingBrag!!.bragId, 0, imageUri, content)
+                    editingBrag = null
+                    android.widget.Toast.makeText(context, "자랑글이 성공적으로 수정되었습니다!", android.widget.Toast.LENGTH_SHORT).show()
+                } else {
+                    onSubmitBrag(0, imageUri, content)
+                }
+            },
+            isSubmitting = isBragSubmitting
         )
     }
 
@@ -274,6 +388,93 @@ fun StoreDetailScreen(
             containerColor = Color.White,
             properties = DialogProperties(usePlatformDefaultWidth = true)
         )
+    }
+
+    if (bragToDelete != null) {
+        AlertDialog(
+            onDismissRequest = { bragToDelete = null },
+            title = {
+                Text(
+                    text = "자랑글 삭제",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                    color = Color(0xFF1A1A2E)
+                )
+            },
+            text = {
+                Text(
+                    text = "작성하신 자랑글을 정말로 삭제하시겠습니까?\n삭제된 자랑글은 복구할 수 없습니다.",
+                    fontSize = 14.sp,
+                    color = Color(0xFF4B5563)
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        bragToDelete?.let { onDeleteBrag(it) }
+                        bragToDelete = null
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFEF4444)),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("삭제", color = Color.White)
+                }
+            },
+            dismissButton = {
+                OutlinedButton(
+                    onClick = { bragToDelete = null },
+                    shape = RoundedCornerShape(8.dp),
+                    border = BorderStroke(1.dp, Color(0xFFD1D5DB))
+                ) {
+                    Text("취소", color = Color(0xFF4B5563))
+                }
+            },
+            containerColor = Color.White,
+            properties = DialogProperties(usePlatformDefaultWidth = true)
+        )
+    }
+
+    if (zoomedImageUri != null) {
+        Dialog(
+            onDismissRequest = { zoomedImageUri = null },
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false,
+                dismissOnBackPress = true,
+                dismissOnClickOutside = true
+            )
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.9f))
+                    .clickable { zoomedImageUri = null },
+                contentAlignment = Alignment.Center
+            ) {
+                AsyncImage(
+                    model = zoomedImageUri,
+                    contentDescription = "자랑 원본 이미지",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .fillMaxHeight(0.85f)
+                        .padding(16.dp),
+                    contentScale = ContentScale.Fit
+                )
+
+                IconButton(
+                    onClick = { zoomedImageUri = null },
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(top = 40.dp, end = 20.dp)
+                        .background(Color.Black.copy(alpha = 0.5f), shape = CircleShape)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "닫기",
+                        tint = Color.White
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -1113,7 +1314,7 @@ private fun ReviewListItemCard(
                                 text = "수정",
                                 fontSize = 11.sp,
                                 fontWeight = FontWeight.Bold,
-                                color = Color(0xFF6B7280),
+                                color = Color(0xFF3B6EF8),
                                 modifier = Modifier.clickable { onEditClick() }
                             )
                             Text(
@@ -1564,6 +1765,978 @@ private fun StoreReviewWriteDialog(
 }
 
 // ──────────────────────────────────────────────────────────────
+// 자랑하기 관련 컴포넌트들
+// ──────────────────────────────────────────────────────────────
+
+@Composable
+private fun BragSectionHeader(
+    bragCount: Int,
+    onWriteClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            .padding(top = 16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text(
+                text = "🎉 자랑하기",
+                fontWeight = FontWeight.Bold,
+                fontSize = 18.sp,
+                color = Color(0xFF1A1A2E)
+            )
+        }
+
+        // 자랑하기 작성 버튼 (그라데이션 버튼)
+        val bragGradient = Brush.horizontalGradient(
+            colors = listOf(Color(0xFFF6339A), Color(0xFFAD46FF))
+        )
+        
+        Box(
+            modifier = Modifier
+                .clip(RoundedCornerShape(12.dp))
+                .background(bragGradient)
+                .clickable { onWriteClick() }
+                .padding(horizontal = 14.dp, vertical = 8.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = com.example.pickitpickit.R.drawable.ic_profile),
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier.size(16.dp)
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                Text(
+                    text = "자랑하기 작성",
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun BragEmptyCard(
+    onWriteClick: () -> Unit
+) {
+    val bragGradient = Brush.horizontalGradient(
+        colors = listOf(Color(0xFFF6339A), Color(0xFFAD46FF))
+    )
+    
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(24.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        border = BorderStroke(
+            1.dp,
+            Brush.horizontalGradient(
+                listOf(Color(0xFFF6339A).copy(alpha = 0.2f), Color(0xFFAD46FF).copy(alpha = 0.2f))
+            )
+        ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 40.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            // 스파클 아이콘 컨테이너
+            Box(
+                modifier = Modifier
+                    .size(90.dp)
+                    .clip(CircleShape)
+                    .background(Color(0xFFF6339A).copy(alpha = 0.08f)),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(id = com.example.pickitpickit.R.drawable.ic_tag),
+                    contentDescription = null,
+                    tint = Color.White,
+                    modifier = Modifier
+                        .size(42.dp)
+                        .graphicsLayer(alpha = 0.99f)
+                        .drawWithCache {
+                            onDrawWithContent {
+                                drawContent()
+                                drawRect(
+                                    brush = bragGradient,
+                                    blendMode = BlendMode.SrcAtop
+                                )
+                            }
+                        }
+                )
+            }
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = "아직 자랑하기가 없어요",
+                fontSize = 16.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF1A1A2E)
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Text(
+                text = "이 매장에서 뽑은 인형이나 가챠를 자랑해보세요!",
+                fontSize = 13.sp,
+                color = Color(0xFF6B7280)
+            )
+
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // 첫 번째 자랑하기 작성 버튼
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(12.dp))
+                    .background(bragGradient)
+                    .clickable { onWriteClick() }
+                    .padding(horizontal = 20.dp, vertical = 10.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.Center
+                ) {
+                    Icon(
+                        painter = painterResource(id = com.example.pickitpickit.R.drawable.ic_profile),
+                        contentDescription = null,
+                        tint = Color.White,
+                        modifier = Modifier.size(16.dp)
+                    )
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text(
+                        text = "첫 번째 자랑하기 작성",
+                        fontSize = 13.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BragListItemCard(
+    brag: com.example.pickitpickit.core.model.BragDto,
+    currentUserId: Long?,
+    onDeleteClick: () -> Unit,
+    onEditClick: () -> Unit,
+    onImageClick: (String) -> Unit
+) {
+    val (title, description, storeName, tags) = parseBragContent(brag.content)
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 6.dp),
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White),
+        elevation = CardDefaults.cardElevation(defaultElevation = 1.dp)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp)
+        ) {
+            // 작성자 프로필
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (!brag.authorProfileImageUrl.isNullOrEmpty()) {
+                    AsyncImage(
+                        model = brag.authorProfileImageUrl,
+                        contentDescription = "프로필 이미지",
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape),
+                        contentScale = ContentScale.Crop
+                    )
+                } else {
+                    Box(
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape)
+                            .background(Color(0xFFF3F4F6)),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text("👤", fontSize = 16.sp)
+                    }
+                }
+
+                Spacer(modifier = Modifier.width(10.dp))
+
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = brag.authorNickname,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1A2E)
+                    )
+                    Spacer(modifier = Modifier.height(2.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        val formattedDate = try {
+                            val isoDateTime = brag.createdAt
+                            if (isoDateTime.contains("T")) {
+                                val datePart = isoDateTime.split("T")[0]
+                                val timePart = isoDateTime.split("T")[1].substring(0, 5)
+                                "$datePart $timePart"
+                            } else {
+                                isoDateTime
+                            }
+                        } catch (e: Exception) {
+                            brag.createdAt
+                        }
+                        Text(
+                            text = formattedDate,
+                            fontSize = 11.sp,
+                            color = Color(0xFF9CA3AF)
+                        )
+                        if (brag.userId == currentUserId) {
+                            Text(
+                                text = " • ",
+                                fontSize = 11.sp,
+                                color = Color(0xFF9CA3AF)
+                            )
+                            Text(
+                                text = "수정",
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color(0xFF3B6EF8),
+                                modifier = Modifier.clickable { onEditClick() }
+                            )
+                            Text(
+                                text = " • ",
+                                fontSize = 11.sp,
+                                color = Color(0xFF9CA3AF)
+                            )
+                            Text(
+                                text = "삭제",
+                                fontSize = 11.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = Color(0xFFEF4444),
+                                modifier = Modifier.clickable { onDeleteClick() }
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 자랑 이미지
+            AsyncImage(
+                model = brag.imageUrl,
+                contentDescription = "자랑 이미지",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(200.dp)
+                    .clip(RoundedCornerShape(12.dp))
+                    .clickable { onImageClick(brag.imageUrl) },
+                contentScale = ContentScale.Crop
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            // 제목
+            Text(
+                text = title,
+                fontSize = 15.sp,
+                fontWeight = FontWeight.Bold,
+                color = Color(0xFF1A1A2E)
+            )
+
+            if (!description.isNullOrEmpty()) {
+                Spacer(modifier = Modifier.height(6.dp))
+                Text(
+                    text = description,
+                    fontSize = 13.sp,
+                    color = Color(0xFF4B5563),
+                    lineHeight = 18.sp
+                )
+            }
+
+            if (!storeName.isNullOrEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text("📍", fontSize = 12.sp)
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(
+                        text = storeName,
+                        fontSize = 12.sp,
+                        color = Color(0xFF3B6EF8),
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+
+            if (tags.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(10.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    tags.forEach { tag ->
+                        Text(
+                            text = "#$tag",
+                            fontSize = 11.sp,
+                            color = Color(0xFFAD46FF),
+                            modifier = Modifier
+                                .clip(RoundedCornerShape(6.dp))
+                                .background(Color(0xFFF5F3FF))
+                                .padding(horizontal = 8.dp, vertical = 3.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StoreBragWriteDialog(
+    storeName: String,
+    bragToEdit: com.example.pickitpickit.core.model.BragDto? = null,
+    onDismiss: () -> Unit,
+    onSubmit: (String, String) -> Unit, // (imageUrl, content)
+    isSubmitting: Boolean
+) {
+    val parsedContent = remember(bragToEdit) {
+        bragToEdit?.let { parseBragContent(it.content) }
+    }
+
+    var title by remember { mutableStateOf(parsedContent?.first ?: "") }
+    var description by remember { mutableStateOf(parsedContent?.second ?: "") }
+    var customStoreName by remember { mutableStateOf(parsedContent?.third ?: storeName) }
+    var selectedImageUri by remember { mutableStateOf<String?>(bragToEdit?.imageUrl) }
+    var tagInput by remember { mutableStateOf("") }
+    var tagsList by remember { mutableStateOf(parsedContent?.fourth ?: emptyList<String>()) }
+    
+    val titleLimit = 50
+    val descLimit = 300
+    val maxTags = 5
+
+    // 카메라/갤러리 선택 팝업 상태
+    var showPhotoSourceDialog by remember { mutableStateOf(false) }
+
+    val context = androidx.compose.ui.platform.LocalContext.current
+
+    // 카메라 사진 저장을 위한 임시 파일 및 URI 관리
+    var tempPhotoUri by remember { mutableStateOf<android.net.Uri?>(null) }
+
+    // 갤러리 이미지 선택 런처
+    val pickMediaLauncher = rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia()
+    ) { uri ->
+        if (uri != null) {
+            try {
+                context.contentResolver.openInputStream(uri)?.use { inputStream ->
+                    val timeStamp = java.text.SimpleDateFormat("yyyyMMdd_HHmmss", java.util.Locale.US).format(java.util.Date())
+                    val storageDir = context.getExternalFilesDir(android.os.Environment.DIRECTORY_PICTURES)
+                    val file = java.io.File.createTempFile("BRAG_${timeStamp}_", ".jpg", storageDir)
+                    file.outputStream().use { outputStream ->
+                        inputStream.copyTo(outputStream)
+                    }
+                    val fileProviderUri = androidx.core.content.FileProvider.getUriForFile(
+                        context,
+                        "${context.packageName}.fileprovider",
+                        file
+                    )
+                    selectedImageUri = fileProviderUri.toString()
+                }
+            } catch (e: Exception) {
+                Log.e("GALLERY_FLOW", "갤러리 이미지 복사 에러", e)
+                android.widget.Toast.makeText(context, "이미지를 가져오는 데 실패했습니다.", android.widget.Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    // 카메라 촬영 런처
+    val takePictureLauncher = rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.TakePicture()
+    ) { success ->
+        if (success && tempPhotoUri != null) {
+            selectedImageUri = tempPhotoUri.toString()
+        }
+    }
+
+    // 카메라 권한 런처
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = androidx.activity.result.contract.ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            tempPhotoUri?.let { takePictureLauncher.launch(it) }
+        } else {
+            android.widget.Toast.makeText(context, "사진을 찍기 위해 카메라 권한이 필요합니다.", android.widget.Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    // 헬퍼: 카메라 띄우기 전 권한 확인 및 임시 파일 생성
+    fun launchCameraFlow() {
+        try {
+            val timeStamp = java.text.SimpleDateFormat("yyyyMMdd_HHmmss", java.util.Locale.US).format(java.util.Date())
+            val storageDir = context.getExternalFilesDir(android.os.Environment.DIRECTORY_PICTURES)
+            val file = java.io.File.createTempFile("JPEG_${timeStamp}_", ".jpg", storageDir)
+            val uri = androidx.core.content.FileProvider.getUriForFile(
+                context,
+                "${context.packageName}.fileprovider",
+                file
+            )
+            tempPhotoUri = uri
+
+            // 권한 체크
+            val permissionCheck = androidx.core.content.ContextCompat.checkSelfPermission(
+                context,
+                android.Manifest.permission.CAMERA
+            )
+            if (permissionCheck == android.content.pm.PackageManager.PERMISSION_GRANTED) {
+                takePictureLauncher.launch(uri)
+            } else {
+                cameraPermissionLauncher.launch(android.Manifest.permission.CAMERA)
+            }
+        } catch (e: Exception) {
+            Log.e("CAMERA_FLOW", "카메라 촬영 준비 에러", e)
+            android.widget.Toast.makeText(context, "카메라 실행 준비에 실패했습니다.", android.widget.Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    val scrollState = rememberScrollState()
+
+    if (showPhotoSourceDialog) {
+        AlertDialog(
+            onDismissRequest = { showPhotoSourceDialog = false },
+            title = {
+                Text(
+                    text = "사진 추가하기",
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 18.sp,
+                    color = Color(0xFF1A1A2E)
+                )
+            },
+            text = {
+                Text(
+                    text = "어떤 방법으로 사진을 추가하시겠습니까?",
+                    fontSize = 14.sp,
+                    color = Color(0xFF4B5563)
+                )
+            },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        showPhotoSourceDialog = false
+                        launchCameraFlow()
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF3B6EF8)),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("직접 촬영", color = Color.White)
+                }
+            },
+            dismissButton = {
+                Button(
+                    onClick = {
+                        showPhotoSourceDialog = false
+                        pickMediaLauncher.launch(
+                            androidx.activity.result.PickVisualMediaRequest(
+                                androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia.ImageOnly
+                            )
+                        )
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF4B5563)),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("갤러리에서 선택", color = Color.White)
+                }
+            },
+            containerColor = Color.White,
+            properties = DialogProperties(usePlatformDefaultWidth = true)
+        )
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxWidth(0.92f)
+                .fillMaxHeight(0.90f)
+                .padding(vertical = 16.dp),
+            shape = RoundedCornerShape(24.dp),
+            colors = CardDefaults.cardColors(containerColor = Color.White),
+            elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(24.dp)
+            ) {
+                // 상단 X 닫기 버튼 영역
+                Box(modifier = Modifier.fillMaxWidth()) {
+                    IconButton(
+                        onClick = onDismiss,
+                        modifier = Modifier.align(Alignment.TopEnd)
+                    ) {
+                        Text("✕", fontSize = 16.sp, color = Color(0xFF9CA3AF))
+                    }
+                }
+
+                // 스크롤 가능한 본문 영역
+                Column(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .verticalScroll(scrollState)
+                ) {
+                    Text(
+                        text = if (bragToEdit != null) "✏️ 자랑하기 수정" else "🎉 자랑하기",
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = Color(0xFF1A1A2E)
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Text(
+                        text = if (bragToEdit != null) "작성하신 자랑글 내용을 수정해 보세요!" else "내가 뽑은 인형이나 가챠를 자랑해보세요!",
+                        fontSize = 13.sp,
+                        color = Color(0xFF6B7280)
+                    )
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    // 1. 사진 선택 영역 (필수)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("사진", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color(0xFF374151))
+                        Spacer(modifier = Modifier.width(3.dp))
+                        Text("*", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color.Red)
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    // 점선 테두리 상자
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(180.dp)
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(Color(0xFFF9FAFB))
+                            .drawBehind {
+                                val stroke = Stroke(
+                                    width = 3f,
+                                    pathEffect = PathEffect.dashPathEffect(floatArrayOf(15f, 15f), 0f)
+                                )
+                                drawRoundRect(
+                                    color = Color(0xFFD1D5DB),
+                                    style = stroke,
+                                    cornerRadius = CornerRadius(12.dp.toPx())
+                                )
+                            }
+                            .clickable(enabled = !isSubmitting) {
+                                showPhotoSourceDialog = true
+                            },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (selectedImageUri != null) {
+                            Box(modifier = Modifier.fillMaxSize()) {
+                                AsyncImage(
+                                    model = selectedImageUri,
+                                    contentDescription = "선택된 이미지",
+                                    modifier = Modifier.fillMaxSize().clip(RoundedCornerShape(12.dp)),
+                                    contentScale = ContentScale.Crop
+                                )
+                                // 이미지 위에 닫기 버튼 배치
+                                if (!isSubmitting) {
+                                    Box(
+                                        modifier = Modifier
+                                            .align(Alignment.TopEnd)
+                                            .padding(8.dp)
+                                            .size(24.dp)
+                                            .clip(CircleShape)
+                                            .background(Color.Black.copy(alpha = 0.6f))
+                                            .clickable { selectedImageUri = null },
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        Text("✕", color = Color.White, fontSize = 12.sp)
+                                    }
+                                }
+                            }
+                        } else {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally,
+                                verticalArrangement = Arrangement.Center
+                            ) {
+                                Box(
+                                    modifier = Modifier
+                                        .size(56.dp)
+                                        .clip(CircleShape)
+                                        .background(Color(0xFFEEF2FF)),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Icon(
+                                        painter = painterResource(id = com.example.pickitpickit.R.drawable.ic_profile),
+                                        contentDescription = null,
+                                        tint = Color(0xFF3B6EF8),
+                                        modifier = Modifier.size(24.dp)
+                                    )
+                                }
+                                Spacer(modifier = Modifier.height(10.dp))
+                                Text("사진 추가하기", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color(0xFF374151))
+                                Spacer(modifier = Modifier.height(2.dp))
+                                Text("클릭하여 이미지 업로드", fontSize = 11.sp, color = Color(0xFF9CA3AF))
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    // 2. 제목 입력 (필수)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text("제목", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color(0xFF374151))
+                        Spacer(modifier = Modifier.width(3.dp))
+                        Text("*", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color.Red)
+                    }
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    TextField(
+                        value = title,
+                        onValueChange = {
+                            if (it.length <= titleLimit) title = it
+                        },
+                        enabled = !isSubmitting,
+                        placeholder = {
+                            Text("예: 드디어 뽑았어요! 🎉", fontSize = 13.sp, color = Color(0xFF9CA3AF))
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp)),
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color(0xFFF9FAFB),
+                            unfocusedContainerColor = Color(0xFFF9FAFB),
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        textStyle = TextStyle(fontSize = 13.sp, color = Color(0xFF1F2937)),
+                        singleLine = true
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Text(
+                        text = "${title.length}/$titleLimit",
+                        fontSize = 11.sp,
+                        color = Color(0xFF9CA3AF),
+                        modifier = Modifier.align(Alignment.End)
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // 3. 설명 입력 (선택)
+                    Text("설명 (선택사항)", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color(0xFF374151))
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    TextField(
+                        value = description,
+                        onValueChange = {
+                            if (it.length <= descLimit) description = it
+                        },
+                        enabled = !isSubmitting,
+                        placeholder = {
+                            Text("뽑기 성공 스토리를 들려주세요!", fontSize = 13.sp, color = Color(0xFF9CA3AF))
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(120.dp)
+                            .clip(RoundedCornerShape(12.dp)),
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color(0xFFF9FAFB),
+                            unfocusedContainerColor = Color(0xFFF9FAFB),
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        textStyle = TextStyle(fontSize = 13.sp, color = Color(0xFF1F2937)),
+                        maxLines = 5
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Text(
+                        text = "${description.length}/$descLimit",
+                        fontSize = 11.sp,
+                        color = Color(0xFF9CA3AF),
+                        modifier = Modifier.align(Alignment.End)
+                    )
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    // 4. 매장명 (선택)
+                    Text("매장명 (선택사항)", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color(0xFF374151))
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    TextField(
+                        value = customStoreName,
+                        onValueChange = { customStoreName = it },
+                        enabled = !isSubmitting,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp)),
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = Color(0xFFF9FAFB),
+                            unfocusedContainerColor = Color(0xFFF9FAFB),
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent
+                        ),
+                        textStyle = TextStyle(fontSize = 13.sp, color = Color(0xFF1F2937)),
+                        singleLine = true
+                    )
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    // 5. 태그 입력 (선택, 최대 5개)
+                    Text("태그 (선택사항, 최대 5개)", fontSize = 14.sp, fontWeight = FontWeight.Bold, color = Color(0xFF374151))
+
+                    Spacer(modifier = Modifier.height(8.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        TextField(
+                            value = tagInput,
+                            onValueChange = { tagInput = it },
+                            enabled = !isSubmitting,
+                            placeholder = {
+                                Text("태그 입력 후 추가 버튼", fontSize = 13.sp, color = Color(0xFF9CA3AF))
+                            },
+                            modifier = Modifier
+                                .weight(1f)
+                                .clip(RoundedCornerShape(12.dp)),
+                            colors = TextFieldDefaults.colors(
+                                focusedContainerColor = Color(0xFFF9FAFB),
+                                unfocusedContainerColor = Color(0xFFF9FAFB),
+                                focusedIndicatorColor = Color.Transparent,
+                                unfocusedIndicatorColor = Color.Transparent
+                            ),
+                            textStyle = TextStyle(fontSize = 13.sp, color = Color(0xFF1F2937)),
+                            singleLine = true
+                        )
+
+                        Button(
+                            onClick = {
+                                val trimmed = tagInput.trim()
+                                if (trimmed.isNotEmpty() && tagsList.size < maxTags && !tagsList.contains(trimmed)) {
+                                    tagsList = tagsList + trimmed
+                                    tagInput = ""
+                                }
+                            },
+                            enabled = !isSubmitting,
+                            shape = RoundedCornerShape(10.dp),
+                            border = BorderStroke(1.dp, Color(0xFF3B6EF8)),
+                            colors = ButtonDefaults.buttonColors(
+                                containerColor = Color.White,
+                                contentColor = Color(0xFF3B6EF8)
+                            ),
+                            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+                        ) {
+                            Text("추가", fontSize = 13.sp, fontWeight = FontWeight.Bold)
+                        }
+                    }
+
+                    // 추가된 태그들 칩으로 표시
+                    if (tagsList.isNotEmpty()) {
+                        Spacer(modifier = Modifier.height(10.dp))
+                        
+                        androidx.compose.foundation.lazy.LazyRow(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            modifier = Modifier.fillMaxWidth()
+                        ) {
+                            items(tagsList) { tag ->
+                                Row(
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    modifier = Modifier
+                                        .clip(RoundedCornerShape(6.dp))
+                                        .background(Color(0xFFF5F3FF))
+                                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                                ) {
+                                    Text(
+                                        text = "#$tag",
+                                        fontSize = 11.sp,
+                                        color = Color(0xFFAD46FF)
+                                    )
+                                    if (!isSubmitting) {
+                                        Spacer(modifier = Modifier.width(4.dp))
+                                        Text(
+                                            text = "✕",
+                                            fontSize = 10.sp,
+                                            color = Color(0xFF9CA3AF),
+                                            modifier = Modifier.clickable {
+                                                tagsList = tagsList.filter { it != tag }
+                                            }
+                                        )
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.height(24.dp))
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // 하단 취소 / 게시하기 버튼 영역
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                ) {
+                    OutlinedButton(
+                        onClick = onDismiss,
+                        enabled = !isSubmitting,
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.outlinedButtonColors(contentColor = Color(0xFF6B7280)),
+                        modifier = Modifier
+                            .weight(1f)
+                            .height(46.dp)
+                    ) {
+                        Text("취소", fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                    }
+
+                    val buttonEnabled = selectedImageUri != null && title.isNotBlank() && !isSubmitting
+
+                    Button(
+                        onClick = {
+                            if (selectedImageUri == null) return@Button
+                            if (title.isBlank()) return@Button
+
+                            // 포맷에 맞춘 content 조립
+                            val finalContent = buildString {
+                                append(title)
+                                if (description.isNotBlank()) {
+                                    append("\n\n")
+                                    append(description)
+                                }
+                                if (customStoreName.isNotBlank()) {
+                                    append("\n\n📍")
+                                    append(customStoreName)
+                                }
+                                if (tagsList.isNotEmpty()) {
+                                    append("\n\n")
+                                    append(tagsList.joinToString(" ") { "#$it" })
+                                }
+                            }
+
+                            onSubmit(selectedImageUri!!, finalContent)
+                        },
+                        enabled = buttonEnabled,
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = Color(0xFFFF9800),
+                            disabledContainerColor = Color(0xFFE5E7EB)
+                        ),
+                        modifier = Modifier
+                            .weight(1.5f)
+                            .height(46.dp)
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            if (isSubmitting) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(16.dp),
+                                    color = Color.White,
+                                    strokeWidth = 2.dp
+                                )
+                            } else {
+                                Icon(
+                                    imageVector = Icons.AutoMirrored.Filled.Send,
+                                    contentDescription = null,
+                                    tint = if (buttonEnabled) Color.White else Color(0xFF9CA3AF),
+                                    modifier = Modifier.size(16.dp)
+                                )
+                                Spacer(modifier = Modifier.width(6.dp))
+                                Text(
+                                    text = if (bragToEdit != null) "수정하기" else "게시하기",
+                                    fontSize = 14.sp,
+                                    fontWeight = FontWeight.Bold,
+                                    color = if (buttonEnabled) Color.White else Color(0xFF9CA3AF)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────
+// 헬퍼: 자랑글 content 파싱 함수
+// ──────────────────────────────────────────────────────────────
+private fun parseBragContent(content: String): Tuple4<String, String?, String?, List<String>> {
+    val lines = content.split("\n\n")
+    if (lines.isEmpty()) return Tuple4("", null, null, emptyList())
+    val title = lines[0]
+    var description: String? = null
+    var storeName: String? = null
+    val tags = mutableListOf<String>()
+
+    if (lines.size > 1) {
+        val remaining = lines.subList(1, lines.size)
+        // 마지막 라인이 태그인지 확인
+        val lastLine = remaining.last().trim()
+        val isLastLineTags = lastLine.split(" ").all { it.startsWith("#") }
+        
+        val cleanRemaining = if (isLastLineTags) {
+            lastLine.split(" ").forEach {
+                val clean = it.removePrefix("#").trim()
+                if (clean.isNotEmpty()) tags.add(clean)
+            }
+            remaining.dropLast(1)
+        } else {
+            remaining
+        }
+        
+        val descLines = mutableListOf<String>()
+        cleanRemaining.forEach { line ->
+            if (line.trim().startsWith("📍")) {
+                storeName = line.trim().removePrefix("📍")
+            } else {
+                descLines.add(line)
+            }
+        }
+        if (descLines.isNotEmpty()) {
+            description = descLines.joinToString("\n\n")
+        }
+    }
+    return Tuple4(title, description, storeName, tags)
+}
+
+// kotlin에는 표준 Tuple4가 없으므로 간단히 데이터 클래스로 정의해서 쓴다.
+private data class Tuple4<out A, out B, out C, out D>(
+    val first: A,
+    val second: B,
+    val third: C,
+    val fourth: D
+)
+
+// ──────────────────────────────────────────────────────────────
 // Preview
 // ──────────────────────────────────────────────────────────────
 
@@ -1633,6 +2806,7 @@ fun StoreDetailScreenPreview() {
         StoreDetailScreen(
             storeDetail = dummyStore,
             reviewData = null,
+            bragData = null,
             onBackClick = {},
             onSubmitReview = { _, _, _ -> },
             isReviewSubmitting = false,
@@ -1640,7 +2814,12 @@ fun StoreDetailScreenPreview() {
             currentUserId = null,
             writeGuide = null,
             onEditReview = { _, _, _, _ -> },
-            onDeleteReview = {}
+            onDeleteReview = {},
+            isBragSubmitting = false,
+            bragSubmitResultFlow = kotlinx.coroutines.flow.MutableSharedFlow(),
+            onSubmitBrag = { _, _, _ -> },
+            onDeleteBrag = {},
+            onEditBrag = { _, _, _, _ -> }
         )
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailViewModel.kt
@@ -8,8 +8,12 @@ import com.example.pickitpickit.GlobalApplication
 import com.example.pickitpickit.core.model.ReviewRequest
 import com.example.pickitpickit.core.model.StoreDetailResponse
 import com.example.pickitpickit.core.model.StoreReviewListResponse
+import com.example.pickitpickit.core.model.BragDto
+import com.example.pickitpickit.core.model.BragRequest
+import com.example.pickitpickit.core.model.BragPatchRequest
 import com.example.pickitpickit.core.network.ReviewRepository
 import com.example.pickitpickit.core.network.StoreRepository
+import com.example.pickitpickit.core.network.BragRepository
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -28,7 +32,8 @@ sealed class StoreDetailUiState {
     object Loading : StoreDetailUiState()
     data class Success(
         val detail: StoreDetailResponse,
-        val reviewData: StoreReviewListResponse?
+        val reviewData: StoreReviewListResponse?,
+        val bragData: List<BragDto>?
     ) : StoreDetailUiState()
     data class Error(val message: String) : StoreDetailUiState()
 }
@@ -45,6 +50,7 @@ class StoreDetailViewModel(
 
     private val repository = StoreRepository()
     private val reviewRepository = ReviewRepository()
+    private val bragRepository = BragRepository()
 
     private val _uiState = MutableStateFlow<StoreDetailUiState>(StoreDetailUiState.Loading)
     val uiState: StateFlow<StoreDetailUiState> = _uiState.asStateFlow()
@@ -56,6 +62,14 @@ class StoreDetailViewModel(
     // 리뷰 작성 중 상태
     private val _isReviewSubmitting = MutableStateFlow(false)
     val isReviewSubmitting: StateFlow<Boolean> = _isReviewSubmitting.asStateFlow()
+
+    // 자랑하기 작성 결과 흐름
+    private val _bragSubmitResult = MutableSharedFlow<String?>()
+    val bragSubmitResult: SharedFlow<String?> = _bragSubmitResult.asSharedFlow()
+
+    // 자랑하기 작성 중 상태
+    private val _isBragSubmitting = MutableStateFlow(false)
+    val isBragSubmitting: StateFlow<Boolean> = _isBragSubmitting.asStateFlow()
 
     // 내 리뷰 식별을 위한 사용자 고유 ID 흐름
     private val _currentUserId = MutableStateFlow<Long?>(null)
@@ -99,10 +113,11 @@ class StoreDetailViewModel(
             )
 
             val reviews = reviewRepository.getStoreReviews(storeId.toLong())
+            val brags = bragRepository.getAllBrags()?.filter { it.storeId == storeId.toLong() }
 
             if (detail != null) {
-                Log.i("STORE_DETAIL_VM", "매장 상세 및 리뷰 조회 성공: ${detail.store.name}, 상품 ${detail.productCount}개, 리뷰 ${reviews?.reviewCount ?: 0}개")
-                _uiState.update { StoreDetailUiState.Success(detail, reviews) }
+                Log.i("STORE_DETAIL_VM", "매장 상세 및 리뷰/자랑글 조회 성공: ${detail.store.name}, 상품 ${detail.productCount}개, 리뷰 ${reviews?.reviewCount ?: 0}개, 자랑글 ${brags?.size ?: 0}개")
+                _uiState.update { StoreDetailUiState.Success(detail, reviews, brags) }
             } else {
                 Log.e("STORE_DETAIL_VM", "매장 상세 조회 실패: storeId=$storeId")
                 _uiState.update { StoreDetailUiState.Error("매장 정보를 불러오지 못했어요.\n잠시 후 다시 시도해 주세요.") }
@@ -124,15 +139,20 @@ class StoreDetailViewModel(
             val errorMsg = reviewRepository.postReview(request)
             if (errorMsg == null) {
                 _submitResult.emit("CREATE_SUCCESS")
-                // 작성 성공 시 상세 정보 및 리뷰 목록 다시 로드
-                val detail = repository.getStoreDetail(
-                    storeId = storeId.toLong(),
-                    lat = userLatitude,
-                    lng = userLongitude
-                )
+                val currentState = _uiState.value
                 val reviews = reviewRepository.getStoreReviews(storeId.toLong())
-                if (detail != null) {
-                    _uiState.update { StoreDetailUiState.Success(detail, reviews) }
+                val brags = bragRepository.getAllBrags()?.filter { it.storeId == storeId.toLong() }
+                if (currentState is StoreDetailUiState.Success) {
+                    _uiState.update { currentState.copy(reviewData = reviews, bragData = brags) }
+                } else {
+                    val detail = repository.getStoreDetail(
+                        storeId = storeId.toLong(),
+                        lat = userLatitude,
+                        lng = userLongitude
+                    )
+                    if (detail != null) {
+                        _uiState.update { StoreDetailUiState.Success(detail, reviews, brags) }
+                    }
                 }
             } else {
                 _submitResult.emit(errorMsg)
@@ -154,15 +174,20 @@ class StoreDetailViewModel(
             val errorMsg = reviewRepository.updateReview(reviewId, request)
             if (errorMsg == null) {
                 _submitResult.emit("EDIT_SUCCESS")
-                // 수정 성공 시 상세 정보 및 리뷰 목록 다시 로드
-                val detail = repository.getStoreDetail(
-                    storeId = storeId.toLong(),
-                    lat = userLatitude,
-                    lng = userLongitude
-                )
+                val currentState = _uiState.value
                 val reviews = reviewRepository.getStoreReviews(storeId.toLong())
-                if (detail != null) {
-                    _uiState.update { StoreDetailUiState.Success(detail, reviews) }
+                val brags = bragRepository.getAllBrags()?.filter { it.storeId == storeId.toLong() }
+                if (currentState is StoreDetailUiState.Success) {
+                    _uiState.update { currentState.copy(reviewData = reviews, bragData = brags) }
+                } else {
+                    val detail = repository.getStoreDetail(
+                        storeId = storeId.toLong(),
+                        lat = userLatitude,
+                        lng = userLongitude
+                    )
+                    if (detail != null) {
+                        _uiState.update { StoreDetailUiState.Success(detail, reviews, brags) }
+                    }
                 }
             } else {
                 _submitResult.emit(errorMsg)
@@ -178,20 +203,126 @@ class StoreDetailViewModel(
             val errorMsg = reviewRepository.deleteReview(reviewId, userId)
             if (errorMsg == null) {
                 _submitResult.emit("DELETE_SUCCESS")
-                // 삭제 성공 시 상세 정보 및 리뷰 목록 다시 로드
-                val detail = repository.getStoreDetail(
-                    storeId = storeId.toLong(),
-                    lat = userLatitude,
-                    lng = userLongitude
-                )
+                val currentState = _uiState.value
                 val reviews = reviewRepository.getStoreReviews(storeId.toLong())
-                if (detail != null) {
-                    _uiState.update { StoreDetailUiState.Success(detail, reviews) }
+                val brags = bragRepository.getAllBrags()?.filter { it.storeId == storeId.toLong() }
+                if (currentState is StoreDetailUiState.Success) {
+                    _uiState.update { currentState.copy(reviewData = reviews, bragData = brags) }
+                } else {
+                    val detail = repository.getStoreDetail(
+                        storeId = storeId.toLong(),
+                        lat = userLatitude,
+                        lng = userLongitude
+                    )
+                    if (detail != null) {
+                        _uiState.update { StoreDetailUiState.Success(detail, reviews, brags) }
+                    }
                 }
             } else {
                 _submitResult.emit(errorMsg)
             }
             _isReviewSubmitting.update { false }
+        }
+    }
+
+    fun submitBrag(spentCost: Int, imageUrl: String, content: String) {
+        viewModelScope.launch {
+            _isBragSubmitting.update { true }
+            val userId = GlobalApplication.userPreferences.getUserId().first() ?: 0L
+            val request = BragRequest(
+                userId = userId,
+                storeId = storeId.toLong(),
+                spentCost = spentCost,
+                imageUrl = imageUrl,
+                content = content
+            )
+            val errorMsg = bragRepository.postBrag(request)
+            if (errorMsg == null) {
+                _bragSubmitResult.emit("CREATE_SUCCESS")
+                val currentState = _uiState.value
+                val reviews = reviewRepository.getStoreReviews(storeId.toLong())
+                val brags = bragRepository.getAllBrags()?.filter { it.storeId == storeId.toLong() }
+                if (currentState is StoreDetailUiState.Success) {
+                    _uiState.update { currentState.copy(reviewData = reviews, bragData = brags) }
+                } else {
+                    val detail = repository.getStoreDetail(
+                        storeId = storeId.toLong(),
+                        lat = userLatitude,
+                        lng = userLongitude
+                    )
+                    if (detail != null) {
+                        _uiState.update { StoreDetailUiState.Success(detail, reviews, brags) }
+                    }
+                }
+            } else {
+                _bragSubmitResult.emit(errorMsg)
+            }
+            _isBragSubmitting.update { false }
+        }
+    }
+
+    fun editBrag(bragId: Long, spentCost: Int, imageUrl: String, content: String) {
+        viewModelScope.launch {
+            _isBragSubmitting.update { true }
+            val userId = _currentUserId.value ?: GlobalApplication.userPreferences.getUserId().first() ?: 0L
+            val request = BragPatchRequest(
+                userId = userId,
+                storeId = storeId.toLong(),
+                spentCost = spentCost,
+                imageUrl = imageUrl,
+                content = content
+            )
+            val errorMsg = bragRepository.updateBrag(bragId, request)
+            if (errorMsg == null) {
+                _bragSubmitResult.emit("EDIT_SUCCESS")
+                val currentState = _uiState.value
+                val reviews = reviewRepository.getStoreReviews(storeId.toLong())
+                val brags = bragRepository.getAllBrags()?.filter { it.storeId == storeId.toLong() }
+                if (currentState is StoreDetailUiState.Success) {
+                    _uiState.update { currentState.copy(reviewData = reviews, bragData = brags) }
+                } else {
+                    val detail = repository.getStoreDetail(
+                        storeId = storeId.toLong(),
+                        lat = userLatitude,
+                        lng = userLongitude
+                    )
+                    if (detail != null) {
+                        _uiState.update { StoreDetailUiState.Success(detail, reviews, brags) }
+                    }
+                }
+            } else {
+                _bragSubmitResult.emit(errorMsg)
+            }
+            _isBragSubmitting.update { false }
+        }
+    }
+
+    fun removeBrag(bragId: Long) {
+        viewModelScope.launch {
+            _isBragSubmitting.update { true }
+            val userId = _currentUserId.value ?: GlobalApplication.userPreferences.getUserId().first() ?: 0L
+            val errorMsg = bragRepository.deleteBrag(bragId, userId)
+            if (errorMsg == null) {
+                _bragSubmitResult.emit("DELETE_SUCCESS")
+                val currentState = _uiState.value
+                val reviews = reviewRepository.getStoreReviews(storeId.toLong())
+                val brags = bragRepository.getAllBrags()?.filter { it.storeId == storeId.toLong() }
+                if (currentState is StoreDetailUiState.Success) {
+                    _uiState.update { currentState.copy(reviewData = reviews, bragData = brags) }
+                } else {
+                    val detail = repository.getStoreDetail(
+                        storeId = storeId.toLong(),
+                        lat = userLatitude,
+                        lng = userLongitude
+                    )
+                    if (detail != null) {
+                        _uiState.update { StoreDetailUiState.Success(detail, reviews, brags) }
+                    }
+                }
+            } else {
+                _bragSubmitResult.emit(errorMsg)
+            }
+            _isBragSubmitting.update { false }
         }
     }
 

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-files-path name="my_images" path="Pictures" />
+    <cache-path name="my_cache_images" path="images" />
+</paths>


### PR DESCRIPTION
- 존재하지 않는 매장별 자랑글 조회 API(getStoreBrags) 제거
- 자랑글 작성자 프로필 이미지 연동 및 이미지 터치 시 원본 팝업 구현
- 자랑글 수정(Edit) 기능 연동 및 작성 다이얼로그 프리필 지원
- 갤러리 선택 이미지의 임시 URI 만료 현상 해결 (앱 내부 저장소 복사본 사용)
- 리뷰 수정 버튼 색상을 자랑하기와 동일한 파란색(0xFF3B6EF8)으로 통일

Closes #30 