### PR TITLE
feat: 관심 매장 기능 연동, 지도 마커 클릭 이동 및 UI 레이아웃 최적화

### DIFF
--- a/app/src/main/java/com/example/pickitpickit/MainActivity.kt
+++ b/app/src/main/java/com/example/pickitpickit/MainActivity.kt
@@ -215,19 +215,17 @@ fun MainScreen(mapViewModel: MapViewModel, onLogoutClick: () -> Unit) {
                             if (item == BottomNavMenuItem.MyPage) {
                                 navController.navigate(item.route) {
                                     navController.graph.startDestinationRoute?.let { route ->
-                                        popUpTo(route) { saveState = true }
+                                        popUpTo(route)
                                     }
                                     launchSingleTop = true
-                                    restoreState = true
                                 }
                             } else {
                                 if (currentRoute != BottomNavMenuItem.Home.route) {
                                     navController.navigate(BottomNavMenuItem.Home.route) {
                                         navController.graph.startDestinationRoute?.let { route ->
-                                            popUpTo(route) { saveState = true }
+                                            popUpTo(route)
                                         }
                                         launchSingleTop = true
-                                        restoreState = true
                                     }
                                 }
                                 item.mapCategory?.let { mapViewModel.setCategory(it) }

--- a/app/src/main/java/com/example/pickitpickit/core/model/StoreModels.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/model/StoreModels.kt
@@ -88,3 +88,24 @@ data class StoreTagsUpdateRequest(
     val tags: List<String>
 )
 
+data class FavoriteStoreDto(
+    val id: Long,
+    val sourcePlaceId: String?,
+    val name: String,
+    val type: String,
+    val latitude: Double,
+    val longitude: Double,
+    val distance: Int,
+    val address: String?,
+    val contact: String?,
+    val businessHours: String?,
+    val mainImageUrl: String?,
+    val kakaoDetailUrl: String?
+)
+
+data class FavoriteStoreResponse(
+    val favoriteStoreId: Long,
+    val store: FavoriteStoreDto
+)
+
+

--- a/app/src/main/java/com/example/pickitpickit/core/network/UserRepository.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/UserRepository.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.example.pickitpickit.core.model.MyPageProfileResponse
 import com.example.pickitpickit.core.model.MyPageProfileUpdateRequest
 import com.example.pickitpickit.core.network.RetrofitClient
+import com.example.pickitpickit.core.model.FavoriteStoreResponse
 
 class UserRepository {
 
@@ -74,6 +75,79 @@ class UserRepository {
             }
         } catch (e: Exception) {
             Log.e("USER_REPOSITORY", "회원 탈퇴 예외 발생", e)
+            "네트워크 연결 상태를 확인해 주세요."
+        }
+    }
+
+    /**
+     * 내 관심매장 목록 조회
+     * GET /api/users/me/favorite-stores
+     */
+    suspend fun getFavoriteStores(lat: Double? = null, lng: Double? = null): List<FavoriteStoreResponse>? {
+        return try {
+            val response = RetrofitClient.userApi.getFavoriteStores(lat, lng)
+            if (response.isSuccessful && response.body() != null) {
+                val apiResponse = response.body()!!
+                if (apiResponse.success) {
+                    apiResponse.data
+                } else {
+                    Log.e("USER_REPOSITORY", "관심매장 조회 실패: ${apiResponse.message}")
+                    null
+                }
+            } else {
+                Log.e("USER_REPOSITORY", "관심매장 조회 HTTP 에러: ${response.code()}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("USER_REPOSITORY", "관심매장 조회 예외 발생", e)
+            null
+        }
+    }
+
+    /**
+     * 관심매장 추가
+     * POST /api/users/me/favorite-stores/{storeId}
+     */
+    suspend fun addFavoriteStore(storeId: Long): FavoriteStoreResponse? {
+        return try {
+            val response = RetrofitClient.userApi.addFavoriteStore(storeId)
+            if (response.isSuccessful && response.body() != null) {
+                val apiResponse = response.body()!!
+                if (apiResponse.success) {
+                    apiResponse.data
+                } else {
+                    Log.e("USER_REPOSITORY", "관심매장 추가 실패: ${apiResponse.message}")
+                    null
+                }
+            } else {
+                Log.e("USER_REPOSITORY", "관심매장 추가 HTTP 에러: ${response.code()}")
+                null
+            }
+        } catch (e: Exception) {
+            Log.e("USER_REPOSITORY", "관심매장 추가 예외 발생", e)
+            null
+        }
+    }
+
+    /**
+     * 관심매장 삭제
+     * DELETE /api/users/me/favorite-stores/{storeId}
+     */
+    suspend fun deleteFavoriteStore(storeId: Long): String? {
+        return try {
+            val response = RetrofitClient.userApi.deleteFavoriteStore(storeId)
+            if (response.isSuccessful && response.body() != null) {
+                val apiResponse = response.body()!!
+                if (apiResponse.success) {
+                    null // 성공 시 에러 메시지 없음
+                } else {
+                    apiResponse.message
+                }
+            } else {
+                "관심매장 삭제 실패 (HTTP ${response.code()})"
+            }
+        } catch (e: Exception) {
+            Log.e("USER_REPOSITORY", "관심매장 삭제 예외 발생", e)
             "네트워크 연결 상태를 확인해 주세요."
         }
     }

--- a/app/src/main/java/com/example/pickitpickit/core/network/api/UserApi.kt
+++ b/app/src/main/java/com/example/pickitpickit/core/network/api/UserApi.kt
@@ -8,6 +8,10 @@ import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
+import retrofit2.http.POST
+import retrofit2.http.Path
+import retrofit2.http.Query
+import com.example.pickitpickit.core.model.FavoriteStoreResponse
 
 interface UserApi {
 
@@ -33,4 +37,32 @@ interface UserApi {
      */
     @DELETE("api/users/me")
     suspend fun deleteAccount(): Response<ApiResponse<String>>
+
+    /**
+     * 내 관심매장 목록 조회
+     * GET /api/users/me/favorite-stores
+     */
+    @GET("api/users/me/favorite-stores")
+    suspend fun getFavoriteStores(
+        @Query("lat") lat: Double? = null,
+        @Query("lng") lng: Double? = null
+    ): Response<ApiResponse<List<FavoriteStoreResponse>>>
+
+    /**
+     * 관심매장 추가
+     * POST /api/users/me/favorite-stores/{storeId}
+     */
+    @POST("api/users/me/favorite-stores/{storeId}")
+    suspend fun addFavoriteStore(
+        @Path("storeId") storeId: Long
+    ): Response<ApiResponse<FavoriteStoreResponse>>
+
+    /**
+     * 관심매장 삭제
+     * DELETE /api/users/me/favorite-stores/{storeId}
+     */
+    @DELETE("api/users/me/favorite-stores/{storeId}")
+    suspend fun deleteFavoriteStore(
+        @Path("storeId") storeId: Long
+    ): Response<ApiResponse<String>>
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.material.icons.Icons
 
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -48,6 +50,7 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.example.pickitpickit.R
+import com.example.pickitpickit.core.model.FavoriteStoreResponse
 import com.example.pickitpickit.ui.map.MapCategory
 import com.example.pickitpickit.ui.map.MapViewModel
 import coil.compose.AsyncImage
@@ -73,10 +76,16 @@ fun HomeScreen(
     val searchQuery by mapViewModel.searchQuery.collectAsState()
     val recentSearches by mapViewModel.recentSearches.collectAsState()
     val registeredTags by mapViewModel.registeredTags.collectAsState()
+    val favoriteStoreIds by mapViewModel.favoriteStoreIds.collectAsState()
+    val nearbyStores by mapViewModel.nearbyStores.collectAsState()
     val context = LocalContext.current
 
-    // 카테고리 + 검색어 통합 필터링
-    val filteredStores = remember(searchQuery, selectedCategory) {
+    // 매장 마커들을 보관할 리스트
+    val storeLabels = remember { mutableStateListOf<com.kakao.vectormap.label.Label>() }
+    val labelToStoreIdMap = remember { mutableStateMapOf<com.kakao.vectormap.label.Label, Int>() }
+
+    // 카테고리 + 검색어 통합 필터링 (즐겨찾기 변경 및 매장 갱신 시에도 실시간 정렬 반영)
+    val filteredStores = remember(searchQuery, selectedCategory, favoriteStoreIds, nearbyStores) {
         mapViewModel.getFilteredStores()
     }
 
@@ -141,6 +150,7 @@ fun HomeScreen(
     }
 
     LaunchedEffect(Unit) {
+        mapViewModel.loadFavoriteStores()
         locationPermissionLauncher.launch(
             arrayOf(
                 android.Manifest.permission.ACCESS_FINE_LOCATION,
@@ -149,13 +159,18 @@ fun HomeScreen(
         )
     }
 
-    // 지도 준비되면 현재 위치로 이동
+    // 지도 준비되면 현재 위치로 이동 및 마커 클릭 리스너 설정
     LaunchedEffect(kakaoMapInstance) {
-        if (kakaoMapInstance != null) moveToCurrentLocation()
+        val map = kakaoMapInstance ?: return@LaunchedEffect
+        moveToCurrentLocation()
+        map.setOnLabelClickListener { _, _, label ->
+            val storeId = labelToStoreIdMap[label]
+            if (storeId != null) {
+                onStoreClick(storeId)
+            }
+            true
+        }
     }
-
-    // 매장 마커들을 보관할 리스트
-    val storeLabels = remember { mutableStateListOf<com.kakao.vectormap.label.Label>() }
 
     // 매장 목록(filteredStores)이 갱신될 때마다 마커를 지우고 새로 그림
     LaunchedEffect(filteredStores, kakaoMapInstance) {
@@ -165,6 +180,7 @@ fun HomeScreen(
         // 1. 기존 매장 마커 전부 제거
         storeLabels.forEach { label -> layer.remove(label) }
         storeLabels.clear()
+        labelToStoreIdMap.clear()
 
         // 2. 새 매장 마커 추가
         val markerBitmap = getBitmapFromDrawable(context, R.drawable.ic_store_marker)
@@ -176,6 +192,7 @@ fun HomeScreen(
             )
             if (label != null) {
                 storeLabels.add(label)
+                labelToStoreIdMap[label] = store.id
             }
         }
     }
@@ -261,9 +278,11 @@ fun HomeScreen(
                         enter = slideInVertically(initialOffsetY = { -it }) + fadeIn(),
                         exit = slideOutVertically(targetOffsetY = { -it }) + fadeOut()
                     ) {
+                        val favoriteStores by mapViewModel.favoriteStores.collectAsState()
                         SearchDropdownPanel(
                             recentSearches = recentSearches,
                             registeredTags = registeredTags,
+                            favoriteStores = favoriteStores,
                             onSearchSelect = { query ->
                                 mapViewModel.updateSearchQuery(query)
                                 focusManager.clearFocus()
@@ -273,6 +292,10 @@ fun HomeScreen(
                             },
                             onClearAllRecentSearches = {
                                 mapViewModel.clearAllRecentSearches()
+                            },
+                            onStoreClick = { storeId ->
+                                focusManager.clearFocus()
+                                onStoreClick(storeId)
                             }
                         )
                     }
@@ -299,8 +322,7 @@ fun HomeScreen(
         NearbyRecommendButton(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
-                .navigationBarsPadding()
-                .padding(bottom = 16.dp),
+                .padding(bottom = 8.dp),
             onClick = { mapViewModel.showBottomSheet() }
         )
     }
@@ -311,10 +333,13 @@ fun HomeScreen(
             onDismissRequest = { mapViewModel.hideBottomSheet() },
             sheetState = sheetState,
             containerColor = Color.White,
-            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp)
+            shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+            dragHandle = null
         ) {
             NearbyStoreBottomSheet(
                 stores = filteredStores,
+                favoriteStoreIds = favoriteStoreIds,
+                onFavoriteToggle = { mapViewModel.toggleFavoriteStore(it) },
                 onClose = { mapViewModel.hideBottomSheet() },
                 onStoreClick = onStoreClick
             )
@@ -447,9 +472,11 @@ fun SearchBar(
 fun SearchDropdownPanel(
     recentSearches: List<String>,
     registeredTags: List<String>,
+    favoriteStores: List<FavoriteStoreResponse>,
     onSearchSelect: (String) -> Unit,
     onDeleteRecentSearch: (String) -> Unit,
-    onClearAllRecentSearches: () -> Unit
+    onClearAllRecentSearches: () -> Unit,
+    onStoreClick: (Int) -> Unit
 ) {
     Card(
         modifier = Modifier
@@ -524,6 +551,41 @@ fun SearchDropdownPanel(
                 } // forEach 닫기
             } // else 닫기
             
+            Spacer(modifier = Modifier.height(20.dp))
+            HorizontalDivider(color = Color.LightGray.copy(alpha = 0.5f), thickness = 1.dp)
+            Spacer(modifier = Modifier.height(20.dp))
+
+            // 내가 저장한 매장 Title
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.Favorite, contentDescription = null, tint = Color(0xFFF44336), modifier = Modifier.size(18.dp))
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("내가 저장한 매장", fontWeight = FontWeight.Bold, fontSize = 16.sp, color = Color.Black)
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            // 저장한 매장 리스트
+            if (favoriteStores.isEmpty()) {
+                Text(
+                    text = "저장한 매장이 없습니다.",
+                    fontSize = 14.sp,
+                    color = Color.Gray,
+                    modifier = Modifier.padding(start = 28.dp, top = 8.dp)
+                )
+            } else {
+                favoriteStores.forEach { favoriteStore ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onStoreClick(favoriteStore.store.id.toInt()) }
+                            .padding(vertical = 8.dp, horizontal = 4.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.Favorite, contentDescription = null, tint = Color(0xFFF44336).copy(alpha = 0.6f), modifier = Modifier.size(16.dp))
+                        Spacer(modifier = Modifier.width(12.dp))
+                        Text(favoriteStore.store.name, fontSize = 15.sp, color = Color.DarkGray)
+                    }
+                }
+            }
+
             Spacer(modifier = Modifier.height(20.dp))
             HorizontalDivider(color = Color.LightGray.copy(alpha = 0.5f), thickness = 1.dp)
             Spacer(modifier = Modifier.height(20.dp))
@@ -660,7 +722,7 @@ fun NearbyRecommendButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
             .clip(RoundedCornerShape(50.dp))
             .background(Color(0xFF1A1A2E))
             .clickable { onClick() }
-            .padding(horizontal = 32.dp, vertical = 14.dp)
+            .padding(horizontal = 24.dp, vertical = 10.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             Icon(
@@ -688,10 +750,16 @@ fun NearbyRecommendButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
 @Composable
 fun NearbyStoreBottomSheet(
     stores: List<StoreItem>,
+    favoriteStoreIds: Set<Long>,
+    onFavoriteToggle: (Long) -> Unit,
     onClose: () -> Unit,
     onStoreClick: (Int) -> Unit = {}
 ) {
-    Column(modifier = Modifier.fillMaxWidth()) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 16.dp)
+    ) {
         // 핸들
         Box(
             modifier = Modifier
@@ -721,6 +789,8 @@ fun NearbyStoreBottomSheet(
             items(stores) { store ->
                 StoreListItem(
                     store = store,
+                    isFavorite = favoriteStoreIds.contains(store.id.toLong()),
+                    onFavoriteToggle = { onFavoriteToggle(store.id.toLong()) },
                     onClick = { onStoreClick(store.id) }
                 )
             }
@@ -735,6 +805,8 @@ fun NearbyStoreBottomSheet(
 @Composable
 fun StoreListItem(
     store: StoreItem,
+    isFavorite: Boolean,
+    onFavoriteToggle: () -> Unit,
     onClick: () -> Unit = {}
 ) {
     val categoryLabel = when (store.category) {
@@ -808,12 +880,28 @@ fun StoreListItem(
                         overflow = TextOverflow.Ellipsis,
                         modifier = Modifier.weight(1f)
                     )
-                    Text(
-                        text = "${store.distanceMeters}m",
-                        fontSize = 13.sp,
-                        color = Color(0xFF3B6EF8),
-                        fontWeight = FontWeight.Bold
-                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text(
+                            text = "${store.distanceMeters}m",
+                            fontSize = 13.sp,
+                            color = Color(0xFF3B6EF8),
+                            fontWeight = FontWeight.Bold
+                        )
+                        IconButton(
+                            onClick = onFavoriteToggle,
+                            modifier = Modifier.size(24.dp)
+                        ) {
+                            Icon(
+                                imageVector = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                contentDescription = "관심 매장 설정/해제",
+                                tint = if (isFavorite) Color.Red else Color.Gray,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                    }
                 }
 
                 Spacer(modifier = Modifier.height(4.dp))
@@ -911,7 +999,11 @@ fun NearbyRecommendButtonPreview() {
 @Preview(showBackground = true, widthDp = 360)
 @Composable
 fun StoreListItemPreview() {
-    StoreListItem(store = dummyStores.first())
+    StoreListItem(
+        store = dummyStores.first(),
+        isFavorite = false,
+        onFavoriteToggle = {}
+    )
 }
 
 @Preview(showBackground = true, widthDp = 360, heightDp = 600)
@@ -919,6 +1011,8 @@ fun StoreListItemPreview() {
 fun NearbyStoreBottomSheetPreview() {
     NearbyStoreBottomSheet(
         stores = dummyStores,
+        favoriteStoreIds = emptySet(),
+        onFavoriteToggle = {},
         onClose = {}
     )
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.pickitpickit.GlobalApplication
 import com.example.pickitpickit.core.network.SearchRepository
+import com.example.pickitpickit.core.network.UserRepository
 import com.example.pickitpickit.ui.home.StoreItem
 import com.example.pickitpickit.ui.home.dummyStores
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -13,16 +14,26 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
+import com.example.pickitpickit.core.model.FavoriteStoreResponse
 
 class MapViewModel : ViewModel() {
 
     private val searchRepository = SearchRepository()
     private val storeRepository = com.example.pickitpickit.core.network.StoreRepository()
+    private val userRepository = UserRepository()
     private val userPreferences = GlobalApplication.userPreferences
 
     // 사용자 현재 위치 캐싱 (검색 시 정렬 옵션 결합을 위해 보관)
     private var currentLatitude: Double? = null
     private var currentLongitude: Double? = null
+
+    // 즐겨찾기 목록 저장
+    private val _favoriteStoreIds = MutableStateFlow<Set<Long>>(emptySet())
+    val favoriteStoreIds: StateFlow<Set<Long>> = _favoriteStoreIds.asStateFlow()
+
+    // 즐겨찾기 매장 상세 정보 목록 저장
+    private val _favoriteStores = MutableStateFlow<List<FavoriteStoreResponse>>(emptyList())
+    val favoriteStores: StateFlow<List<FavoriteStoreResponse>> = _favoriteStores.asStateFlow()
 
     // 현재 위치 공개 StateFlow (StoreDetailViewModel에 전달용)
     private val _userLatitude = MutableStateFlow<Double?>(null)
@@ -61,6 +72,7 @@ class MapViewModel : ViewModel() {
     init {
         // 뷰모델 생성 시 서버에서 최근 검색어 불러오기
         loadRecentSearches()
+        loadFavoriteStores()
         
         // DataStore 검색 반경 값 동적 구독 연동
         viewModelScope.launch {
@@ -90,6 +102,13 @@ class MapViewModel : ViewModel() {
                 type = type
             )
             _nearbyStores.value = stores
+
+            // 즐겨찾기 최신화
+            val favorites = userRepository.getFavoriteStores(latitude, longitude)
+            if (favorites != null) {
+                _favoriteStoreIds.value = favorites.map { it.store.id }.toSet()
+                _favoriteStores.value = favorites
+            }
         }
     }
 
@@ -136,6 +155,42 @@ class MapViewModel : ViewModel() {
                 lng = currentLongitude
             )
             _nearbyStores.value = stores
+
+            // 즐겨찾기 최신화
+            val favorites = userRepository.getFavoriteStores(currentLatitude, currentLongitude)
+            if (favorites != null) {
+                _favoriteStoreIds.value = favorites.map { it.store.id }.toSet()
+                _favoriteStores.value = favorites
+            }
+        }
+    }
+
+    fun loadFavoriteStores() {
+        viewModelScope.launch {
+            val favorites = userRepository.getFavoriteStores(currentLatitude, currentLongitude)
+            if (favorites != null) {
+                _favoriteStoreIds.value = favorites.map { it.store.id }.toSet()
+                _favoriteStores.value = favorites
+            }
+        }
+    }
+
+    fun toggleFavoriteStore(storeId: Long) {
+        viewModelScope.launch {
+            val isFav = _favoriteStoreIds.value.contains(storeId)
+            if (isFav) {
+                val error = userRepository.deleteFavoriteStore(storeId)
+                if (error == null) {
+                    _favoriteStoreIds.value = _favoriteStoreIds.value - storeId
+                    loadFavoriteStores()
+                }
+            } else {
+                val favResponse = userRepository.addFavoriteStore(storeId)
+                if (favResponse != null) {
+                    _favoriteStoreIds.value = _favoriteStoreIds.value + storeId
+                    loadFavoriteStores()
+                }
+            }
         }
     }
 
@@ -199,12 +254,13 @@ class MapViewModel : ViewModel() {
         _isBottomSheetVisible.value = false
     }
 
-    // 카테고리 + 검색어 + 검색반경(거리단위)을 함께 적용한 필터링 결과
+    // 카테고리 + 검색어 + 검색반경(거리단위)을 함께 적용한 필터링 결과 (좋아요 한 매장 최상단 우선 정렬)
     fun getFilteredStores(): List<StoreItem> {
         val query = _searchQuery.value.trim()
         val cleanQuery = query.removePrefix("#")
         val category = _selectedCategory.value
         val radius = _searchRadius.value
+        val favorites = _favoriteStoreIds.value
 
         return _nearbyStores.value.filter { store ->
             val matchCategory = category == MapCategory.ALL || store.category == category
@@ -218,6 +274,9 @@ class MapViewModel : ViewModel() {
             val matchDistance = store.distanceMeters <= radius
             
             matchCategory && matchQuery && matchDistance
-        }
+        }.sortedWith(
+            compareByDescending<StoreItem> { favorites.contains(it.id.toLong()) }
+                .thenBy { it.distanceMeters }
+        )
     }
 }

--- a/app/src/main/java/com/example/pickitpickit/ui/mypage/FavoriteStoresScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/mypage/FavoriteStoresScreen.kt
@@ -1,0 +1,349 @@
+package com.example.pickitpickit.ui.mypage
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.LocationOn
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import coil.compose.AsyncImage
+import com.example.pickitpickit.core.model.FavoriteStoreResponse
+
+@Composable
+fun FavoriteStoresScreen(
+    onBackClick: () -> Unit,
+    onStoreClick: (Long) -> Unit,
+    viewModel: FavoriteStoresViewModel = viewModel()
+) {
+    val uiState by viewModel.uiState.collectAsState()
+    var storeToDelete by remember { mutableStateOf<Long?>(null) }
+
+    LaunchedEffect(Unit) {
+        viewModel.loadFavoriteStores()
+    }
+
+    // 에러 다이얼로그
+    if (uiState.errorMessage != null) {
+        AlertDialog(
+            onDismissRequest = viewModel::clearError,
+            confirmButton = {
+                TextButton(onClick = viewModel::clearError) {
+                    Text("확인", color = Color(0xFF5393FA), fontWeight = FontWeight.Bold)
+                }
+            },
+            title = { Text("알림", fontWeight = FontWeight.Bold) },
+            text = { Text(uiState.errorMessage ?: "") }
+        )
+    }
+
+    // 관심 매장 해제 확인 다이얼로그
+    if (storeToDelete != null) {
+        AlertDialog(
+            onDismissRequest = { storeToDelete = null },
+            title = { Text("관심 매장 해제", fontWeight = FontWeight.Bold) },
+            text = { Text("이 매장을 관심 매장에서 삭제하시겠습니까?") },
+            confirmButton = {
+                Button(
+                    onClick = {
+                        storeToDelete?.let { viewModel.deleteFavoriteStore(it) }
+                        storeToDelete = null
+                    },
+                    colors = ButtonDefaults.buttonColors(containerColor = Color(0xFFFF4444)),
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("삭제", color = Color.White)
+                }
+            },
+            dismissButton = {
+                OutlinedButton(
+                    onClick = { storeToDelete = null },
+                    shape = RoundedCornerShape(8.dp)
+                ) {
+                    Text("취소", color = Color.Gray)
+                }
+            },
+            containerColor = Color.White
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFFF5F7FA))
+    ) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // ── 상단 그라데이션 타이틀 바 ──────────────────────────
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(
+                        brush = Brush.horizontalGradient(
+                            colors = listOf(Color(0xFF2ACAE7), Color(0xFF4D6FDF))
+                        )
+                    )
+                    .statusBarsPadding()
+                    .padding(vertical = 16.dp)
+            ) {
+                // 뒤로 가기 버튼
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    modifier = Modifier
+                        .align(Alignment.CenterStart)
+                        .clickable(onClick = onBackClick)
+                        .padding(start = 12.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                        contentDescription = "뒤로 가기",
+                        tint = Color.White,
+                        modifier = Modifier.size(24.dp)
+                    )
+                    Spacer(modifier = Modifier.width(2.dp))
+                    Text(
+                        text = "뒤로 가기",
+                        color = Color.White,
+                        fontSize = 14.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+
+                // 타이틀 & 서브타이틀
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        text = "내가 저장한 관심 매장",
+                        color = Color.White,
+                        fontSize = 18.sp,
+                        fontWeight = FontWeight.Bold
+                    )
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = "총 ${uiState.totalFavoritesCount}개의 매장",
+                        color = Color.White.copy(alpha = 0.85f),
+                        fontSize = 12.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                }
+            }
+
+            // ── 매장 목록 영역 ────────────────────────────────────
+            if (uiState.paginatedFavorites.isEmpty() && !uiState.isLoading) {
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                        Text("❤️", fontSize = 48.sp)
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(
+                            text = "저장된 관심 매장이 없습니다.",
+                            color = Color.Gray,
+                            fontSize = 15.sp
+                        )
+                    }
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth()
+                        .padding(top = 16.dp, start = 16.dp, end = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp)
+                ) {
+                    items(uiState.paginatedFavorites) { favorite ->
+                        FavoriteStoreCard(
+                            favorite = favorite,
+                            onStoreClick = onStoreClick,
+                            onDeleteClick = { storeToDelete = favorite.store.id }
+                        )
+                    }
+                }
+            }
+
+            // ── 하단 페이지네이션 영역 ──────────────────────────────
+            if (uiState.totalPages > 1) {
+                PaginationBar(
+                    currentPage = uiState.currentPage,
+                    totalPages = uiState.totalPages,
+                    onPageClick = viewModel::setCurrentPage
+                )
+            } else {
+                Spacer(modifier = Modifier.height(24.dp))
+            }
+        }
+
+        // 로딩 바
+        if (uiState.isLoading) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(Color.Black.copy(alpha = 0.15f))
+                    .clickable(enabled = false) {},
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = Color(0xFF5393FA))
+            }
+        }
+    }
+}
+
+@Composable
+private fun FavoriteStoreCard(
+    favorite: FavoriteStoreResponse,
+    onStoreClick: (Long) -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    val store = favorite.store
+    val categoryLabel = when (store.type.uppercase()) {
+        "CLAW" -> "인형뽑기"
+        "GACHA" -> "가챠"
+        else -> "복합"
+    }
+    val categoryColor = when (store.type.uppercase()) {
+        "CLAW" -> Color(0xFFFF9500)
+        "GACHA" -> Color(0xFF34C759)
+        else -> Color(0xFF5856D6)
+    }
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .shadow(elevation = 4.dp, shape = RoundedCornerShape(16.dp), spotColor = Color(0x0A000000))
+            .border(1.2.dp, Color(0xFFE3EDFD), RoundedCornerShape(16.dp))
+            .clickable { onStoreClick(store.id) },
+        shape = RoundedCornerShape(16.dp),
+        colors = CardDefaults.cardColors(containerColor = Color.White)
+    ) {
+        Row(
+            modifier = Modifier.padding(14.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // 썸네일
+            Box(
+                modifier = Modifier
+                    .size(72.dp)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color(0xFFF3F4F6)),
+                contentAlignment = Alignment.TopStart
+            ) {
+                if (!store.mainImageUrl.isNullOrEmpty()) {
+                    AsyncImage(
+                        model = store.mainImageUrl,
+                        contentDescription = "매장 썸네일",
+                        modifier = Modifier.fillMaxSize(),
+                        contentScale = ContentScale.Crop
+                    )
+                }
+
+                // 카테고리 뱃지
+                Box(
+                    modifier = Modifier
+                        .padding(4.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .background(categoryColor)
+                        .padding(horizontal = 4.dp, vertical = 2.dp)
+                ) {
+                    Text(text = categoryLabel, color = Color.White, fontSize = 8.sp, fontWeight = FontWeight.Bold)
+                }
+            }
+
+            Spacer(modifier = Modifier.width(14.dp))
+
+            // 매장 정보
+            Column(modifier = Modifier.weight(1f)) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = store.name,
+                        fontSize = 15.sp,
+                        fontWeight = FontWeight.Bold,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f)
+                    )
+                    if (store.distance > 0) {
+                        Text(
+                            text = if (store.distance >= 1000) {
+                                String.format("%.1fkm", store.distance / 1000.0)
+                            } else {
+                                "${store.distance}m"
+                            },
+                            fontSize = 12.sp,
+                            color = Color(0xFF3B6EF8),
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        imageVector = Icons.Default.LocationOn,
+                        contentDescription = null,
+                        tint = Color(0xFF888888),
+                        modifier = Modifier.size(12.dp)
+                    )
+                    Spacer(modifier = Modifier.width(2.dp))
+                    Text(
+                        text = store.address ?: "주소 정보 없음",
+                        fontSize = 11.sp,
+                        color = Color.Gray,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+
+                if (!store.businessHours.isNullOrEmpty()) {
+                    Text(
+                        text = "🕐 ${store.businessHours}",
+                        fontSize = 11.sp,
+                        color = Color.Gray,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            // 하트 아이콘 (빨간색 - 클릭 시 해제 다이얼로그)
+            IconButton(
+                onClick = onDeleteClick,
+                modifier = Modifier.size(36.dp)
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Favorite,
+                    contentDescription = "관심 매장 해제",
+                    tint = Color.Red,
+                    modifier = Modifier.size(22.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/mypage/FavoriteStoresViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/mypage/FavoriteStoresViewModel.kt
@@ -1,0 +1,118 @@
+package com.example.pickitpickit.ui.mypage
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.example.pickitpickit.GlobalApplication
+import com.example.pickitpickit.core.model.FavoriteStoreResponse
+import com.example.pickitpickit.core.network.UserRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class FavoriteStoresState(
+    val allFavorites: List<FavoriteStoreResponse> = emptyList(),
+    val paginatedFavorites: List<FavoriteStoreResponse> = emptyList(),
+    val currentPage: Int = 1,
+    val totalPages: Int = 1,
+    val totalFavoritesCount: Int = 0,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null
+)
+
+class FavoriteStoresViewModel(
+    private val userLatitude: Double?,
+    private val userLongitude: Double?
+) : ViewModel() {
+
+    private val userRepository = UserRepository()
+
+    private val _uiState = MutableStateFlow(FavoriteStoresState())
+    val uiState: StateFlow<FavoriteStoresState> = _uiState.asStateFlow()
+
+    private val itemsPerPage = 5
+
+    init {
+        loadFavoriteStores()
+    }
+
+    fun loadFavoriteStores() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            val userId = GlobalApplication.userPreferences.getUserId().first()
+            if (userId == null || userId == 0L) {
+                _uiState.update { it.copy(isLoading = false, errorMessage = "로그인이 필요합니다.") }
+                return@launch
+            }
+
+            val favorites = userRepository.getFavoriteStores(userLatitude, userLongitude)
+            if (favorites != null) {
+                val totalCount = favorites.size
+                val calculatedTotalPages = maxOf(1, java.lang.Math.ceil(totalCount.toDouble() / itemsPerPage).toInt())
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        allFavorites = favorites,
+                        totalFavoritesCount = totalCount,
+                        totalPages = calculatedTotalPages,
+                        currentPage = minOf(currentState.currentPage, calculatedTotalPages),
+                        isLoading = false
+                    )
+                }
+                updatePaginatedList()
+            } else {
+                _uiState.update { it.copy(isLoading = false, errorMessage = "관심 매장 목록을 불러오지 못했습니다.") }
+            }
+        }
+    }
+
+    fun deleteFavoriteStore(storeId: Long) {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            val errorMsg = userRepository.deleteFavoriteStore(storeId)
+            if (errorMsg == null) {
+                Log.i("FAVORITE_STORES_VM", "관심 매장 해제 성공: storeId=$storeId")
+                loadFavoriteStores()
+            } else {
+                _uiState.update { it.copy(isLoading = false, errorMessage = errorMsg) }
+            }
+        }
+    }
+
+    fun setCurrentPage(page: Int) {
+        val maxPage = _uiState.value.totalPages
+        if (page in 1..maxPage) {
+            _uiState.update { it.copy(currentPage = page) }
+            updatePaginatedList()
+        }
+    }
+
+    private fun updatePaginatedList() {
+        val currentState = _uiState.value
+        val startIndex = (currentState.currentPage - 1) * itemsPerPage
+        val endIndex = minOf(startIndex + itemsPerPage, currentState.allFavorites.size)
+        val list = if (startIndex < currentState.allFavorites.size) {
+            currentState.allFavorites.subList(startIndex, endIndex)
+        } else {
+            emptyList()
+        }
+        _uiState.update { it.copy(paginatedFavorites = list) }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
+
+    class Factory(
+        private val userLatitude: Double?,
+        private val userLongitude: Double?
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            return FavoriteStoresViewModel(userLatitude, userLongitude) as T
+        }
+    }
+}

--- a/app/src/main/java/com/example/pickitpickit/ui/mypage/MyPageScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/mypage/MyPageScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Person
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -55,6 +56,7 @@ fun MyPageScreen(
     onLogoutClick: () -> Unit,
     onMyReviewsClick: () -> Unit,
     onMyBragsClick: () -> Unit,
+    onMyFavoriteStoresClick: () -> Unit,
     myPageViewModel: MyPageViewModel = viewModel()
 ) {
     val uiState by myPageViewModel.uiState.collectAsState()
@@ -116,6 +118,7 @@ fun MyPageScreen(
         },
         onMyReviewsClick = onMyReviewsClick,
         onMyBragsClick = onMyBragsClick,
+        onMyFavoriteStoresClick = onMyFavoriteStoresClick,
         onSetPushNotificationsEnabled = myPageViewModel::setPushNotificationsEnabled,
         onSetSearchRadius = myPageViewModel::setSearchRadius
     )
@@ -129,6 +132,7 @@ internal fun MyPageScreenContent(
     onDeleteAccountClick: () -> Unit,
     onMyReviewsClick: () -> Unit,
     onMyBragsClick: () -> Unit,
+    onMyFavoriteStoresClick: () -> Unit,
     onSetPushNotificationsEnabled: (Boolean) -> Unit,
     onSetSearchRadius: (Int) -> Unit
 ) {
@@ -328,6 +332,19 @@ internal fun MyPageScreenContent(
                         title = "작성한 자랑하기",
                         subtitle = "내가 작성한 게시물 ${uiState.bragCount}개",
                         onClick = onMyBragsClick
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(20.dp))
+
+                SectionLabel(text = "관심 매장")
+                SettingsCard {
+                    SettingsItem(
+                        icon = Icons.Default.Favorite,
+                        iconTint = Color(0xFFEF4444),
+                        title = "내가 저장한 매장",
+                        subtitle = "저장한 관심 매장 목록 조회",
+                        onClick = onMyFavoriteStoresClick
                     )
                 }
 
@@ -799,6 +816,7 @@ fun MyPageScreenPreview() {
             onDeleteAccountClick = {},
             onMyReviewsClick = {},
             onMyBragsClick = {},
+            onMyFavoriteStoresClick = {},
             onSetPushNotificationsEnabled = {},
             onSetSearchRadius = {}
         )
@@ -816,6 +834,7 @@ fun MyPageScreenLoadingPreview() {
             onDeleteAccountClick = {},
             onMyReviewsClick = {},
             onMyBragsClick = {},
+            onMyFavoriteStoresClick = {},
             onSetPushNotificationsEnabled = {},
             onSetSearchRadius = {}
         )

--- a/app/src/main/java/com/example/pickitpickit/ui/mypage/MyPageViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/mypage/MyPageViewModel.kt
@@ -98,7 +98,8 @@ class MyPageViewModel : ViewModel() {
 
     fun loadUserProfile() {
         viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+            val showLoading = _uiState.value.nickname.isEmpty()
+            _uiState.update { it.copy(isLoading = showLoading, errorMessage = null) }
             
             val profile = userRepository.getProfile()
             if (profile != null) {

--- a/app/src/main/java/com/example/pickitpickit/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/navigation/NavGraph.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -31,6 +32,8 @@ import com.example.pickitpickit.ui.home.HomeScreen
 import com.example.pickitpickit.ui.mypage.MyPageScreen
 import com.example.pickitpickit.ui.mypage.MyReviewsScreen
 import com.example.pickitpickit.ui.mypage.MyBragsScreen
+import com.example.pickitpickit.ui.mypage.FavoriteStoresScreen
+import com.example.pickitpickit.ui.mypage.FavoriteStoresViewModel
 import com.example.pickitpickit.ui.store.StoreDetailScreen
 import com.example.pickitpickit.ui.store.StoreDetailUiState
 import com.example.pickitpickit.ui.store.StoreDetailViewModel
@@ -65,7 +68,8 @@ fun MainNavGraph(
             MyPageScreen(
                 onLogoutClick = onLogoutClick,
                 onMyReviewsClick = { navController.navigate("my_reviews") },
-                onMyBragsClick = { navController.navigate("my_brags") }
+                onMyBragsClick = { navController.navigate("my_brags") },
+                onMyFavoriteStoresClick = { navController.navigate("favorite_stores") }
             )
         }
         composable("my_reviews") {
@@ -73,6 +77,21 @@ fun MainNavGraph(
         }
         composable("my_brags") {
             MyBragsScreen(onBackClick = { navController.popBackStack() })
+        }
+        composable("favorite_stores") {
+            val favoriteStoresViewModel: FavoriteStoresViewModel = viewModel(
+                factory = FavoriteStoresViewModel.Factory(
+                    userLatitude = userLat,
+                    userLongitude = userLng
+                )
+            )
+            FavoriteStoresScreen(
+                onBackClick = { navController.popBackStack() },
+                onStoreClick = { storeId ->
+                    navController.navigate("store_detail/$storeId")
+                },
+                viewModel = favoriteStoresViewModel
+            )
         }
         composable(
             route = "store_detail/{storeId}",
@@ -89,6 +108,11 @@ fun MainNavGraph(
                     userLongitude = userLng
                 )
             )
+
+            // 화면 진입 및 되돌아올 때마다 즐겨찾기 상태 최신화
+            LaunchedEffect(storeId) {
+                storeDetailViewModel.checkIfFavorite()
+            }
 
             val uiState by storeDetailViewModel.uiState.collectAsState()
 
@@ -158,11 +182,14 @@ fun MainNavGraph(
                     val isBragSubmitting by storeDetailViewModel.isBragSubmitting.collectAsState()
                     val currentUserId by storeDetailViewModel.currentUserId.collectAsState()
                     val writeGuide by storeDetailViewModel.writeGuide.collectAsState()
+                    val isFavorite by storeDetailViewModel.isFavorite.collectAsState()
 
                     StoreDetailScreen(
                         storeDetail = state.detail,
                         reviewData = state.reviewData,
                         bragData = state.bragData,
+                        isFavorite = isFavorite,
+                        onFavoriteToggle = { storeDetailViewModel.toggleFavoriteStore() },
                         onBackClick = { navController.popBackStack() },
                         onSubmitReview = { rating, difficulty, content ->
                             storeDetailViewModel.submitReview(rating, difficulty, content)

--- a/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailScreen.kt
@@ -22,6 +22,8 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -81,6 +83,8 @@ fun StoreDetailScreen(
     storeDetail: StoreDetailResponse,
     reviewData: StoreReviewListResponse?,
     bragData: List<com.example.pickitpickit.core.model.BragDto>?,
+    isFavorite: Boolean,
+    onFavoriteToggle: () -> Unit,
     onBackClick: () -> Unit,
     onSubmitReview: (Double, Int, String?) -> Unit,
     isReviewSubmitting: Boolean,
@@ -184,6 +188,8 @@ fun StoreDetailScreen(
                 storeName = store.name,
                 address = store.address ?: "주소 정보 없음",
                 imageUrl = store.mainImageUrl,
+                isFavorite = isFavorite,
+                onFavoriteToggle = onFavoriteToggle,
                 onBackClick = onBackClick
             )
         }
@@ -494,6 +500,8 @@ private fun StoreHeroSection(
     storeName: String,
     address: String,
     imageUrl: String?,
+    isFavorite: Boolean,
+    onFavoriteToggle: () -> Unit,
     onBackClick: () -> Unit
 ) {
     Box(
@@ -564,6 +572,25 @@ private fun StoreHeroSection(
             )
             Spacer(modifier = Modifier.width(4.dp))
             Text("뒤로 가기", color = Color.White, fontSize = 14.sp, fontWeight = FontWeight.Medium)
+        }
+
+        // 좋아요 하트 버튼
+        Box(
+            modifier = Modifier
+                .statusBarsPadding()
+                .padding(horizontal = 16.dp, vertical = 12.dp)
+                .align(Alignment.TopEnd)
+        ) {
+            val heartIcon = if (isFavorite) Icons.Default.Favorite else Icons.Default.FavoriteBorder
+            val heartColor = if (isFavorite) Color.Red else Color.White
+            Icon(
+                imageVector = heartIcon,
+                contentDescription = "좋아요",
+                tint = heartColor,
+                modifier = Modifier
+                    .size(24.dp)
+                    .clickable { onFavoriteToggle() }
+            )
         }
 
         // 하단 매장명 + 주소
@@ -2828,6 +2855,8 @@ fun StoreDetailScreenPreview() {
             storeDetail = dummyStore,
             reviewData = null,
             bragData = null,
+            isFavorite = false,
+            onFavoriteToggle = {},
             onBackClick = {},
             onSubmitReview = { _, _, _ -> },
             isReviewSubmitting = false,

--- a/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/store/StoreDetailViewModel.kt
@@ -15,6 +15,7 @@ import com.example.pickitpickit.core.network.ReviewRepository
 import com.example.pickitpickit.core.network.StoreRepository
 import com.example.pickitpickit.core.network.BragRepository
 import com.example.pickitpickit.core.network.OwnerRepository
+import com.example.pickitpickit.core.network.UserRepository
 import com.example.pickitpickit.core.network.api.ItemDto
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -95,10 +96,21 @@ class StoreDetailViewModel(
     private val _writeGuide = MutableStateFlow<com.example.pickitpickit.core.model.ReviewWriteGuideResponse?>(null)
     val writeGuide: StateFlow<com.example.pickitpickit.core.model.ReviewWriteGuideResponse?> = _writeGuide.asStateFlow()
 
+    private val userRepository = UserRepository()
+
+    // 관심매장 여부 상태
+    private val _isFavorite = MutableStateFlow(false)
+    val isFavorite: StateFlow<Boolean> = _isFavorite.asStateFlow()
+
+    // 관심매장 추가/삭제 요청 중 상태
+    private val _isFavoriteSubmitting = MutableStateFlow(false)
+    val isFavoriteSubmitting: StateFlow<Boolean> = _isFavoriteSubmitting.asStateFlow()
+
     init {
         loadStoreDetail()
         loadCurrentUserId()
         loadWriteGuide()
+        checkIfFavorite()
     }
 
     private fun loadCurrentUserId() {
@@ -111,6 +123,42 @@ class StoreDetailViewModel(
         viewModelScope.launch {
             val guide = reviewRepository.getReviewWriteGuide()
             _writeGuide.update { guide }
+        }
+    }
+
+    fun checkIfFavorite() {
+        viewModelScope.launch {
+            val favorites = userRepository.getFavoriteStores(userLatitude, userLongitude)
+            if (favorites != null) {
+                val isFav = favorites.any { it.store.id == storeId.toLong() }
+                _isFavorite.value = isFav
+            }
+        }
+    }
+
+    fun toggleFavoriteStore() {
+        if (_isFavoriteSubmitting.value) return
+        viewModelScope.launch {
+            _isFavoriteSubmitting.value = true
+            val currentFav = _isFavorite.value
+            if (currentFav) {
+                val errorMsg = userRepository.deleteFavoriteStore(storeId.toLong())
+                if (errorMsg == null) {
+                    _isFavorite.value = false
+                    _submitResult.emit("FAVORITE_REMOVE_SUCCESS")
+                } else {
+                    _submitResult.emit(errorMsg)
+                }
+            } else {
+                val response = userRepository.addFavoriteStore(storeId.toLong())
+                if (response != null) {
+                    _isFavorite.value = true
+                    _submitResult.emit("FAVORITE_ADD_SUCCESS")
+                } else {
+                    _submitResult.emit("관심 매장 추가에 실패했습니다.")
+                }
+            }
+            _isFavoriteSubmitting.value = false
         }
     }
 


### PR DESCRIPTION
- 마이페이지 내 관심 매장 메뉴 추가 및 목록 페이징 연동
- 매장 상세 페이지 및 지도 검색 결과 리스트에 하트(즐겨찾기) 추가/삭제 토글 구현
- 지도 화면 마커(라벨) 클릭 시 매장 상세 페이지로 이동하도록 리스너 연결
- 검색창 드롭다운 패널에 관심 매장 목록 노출 및 클릭 시 상세 이동 기능 추가
- 하단 탭 이동 시 스택 초기화, 내 주변 추천 버튼 위치 및 바텀시트 핸들바 레이아웃 최적화

Closes #38 