### PR TITLE
chore: 지도 내 주변 추천 버튼 위치 조정, 바텀시트 이중 핸들 제거 및 검색 취소 시 내 주변 데이터 자동 복구 구현

### DIFF
--- a/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/home/HomeScreen.kt
@@ -227,7 +227,10 @@ fun HomeScreen(
                             mapViewModel.updateSearchQuery(inputText)
                             focusManager.clearFocus()
                         },
-                        onClearQuery = { inputText = "" },
+                        onClearQuery = { 
+                            inputText = ""
+                            mapViewModel.updateSearchQuery("")
+                        },
                         isFocused = isSearchFocused,
                         onFocusChanged = { isSearchFocused = it },
                         modifier = Modifier.weight(1f)
@@ -323,6 +326,7 @@ fun HomeScreen(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = 8.dp),
+            searchQuery = searchQuery,
             onClick = { mapViewModel.showBottomSheet() }
         )
     }
@@ -339,6 +343,7 @@ fun HomeScreen(
             NearbyStoreBottomSheet(
                 stores = filteredStores,
                 favoriteStoreIds = favoriteStoreIds,
+                searchQuery = searchQuery,
                 onFavoriteToggle = { mapViewModel.toggleFavoriteStore(it) },
                 onClose = { mapViewModel.hideBottomSheet() },
                 onStoreClick = onStoreClick
@@ -716,7 +721,11 @@ fun MapFabButton(
 // 내 주변 추천 버튼
 // ────────────────────────────────────────────────────────────
 @Composable
-fun NearbyRecommendButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
+fun NearbyRecommendButton(
+    modifier: Modifier = Modifier,
+    searchQuery: String = "",
+    onClick: () -> Unit
+) {
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(50.dp))
@@ -732,8 +741,9 @@ fun NearbyRecommendButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
                 modifier = Modifier.size(18.dp)
             )
             Spacer(modifier = Modifier.width(8.dp))
+            val buttonText = if (searchQuery.isEmpty()) "내 주변 추천" else "검색 결과 보기"
             Text(
-                text = "내 주변 추천",
+                text = buttonText,
                 color = Color.White,
                 fontSize = 15.sp,
                 fontWeight = FontWeight.Bold
@@ -751,6 +761,7 @@ fun NearbyRecommendButton(modifier: Modifier = Modifier, onClick: () -> Unit) {
 fun NearbyStoreBottomSheet(
     stores: List<StoreItem>,
     favoriteStoreIds: Set<Long>,
+    searchQuery: String = "",
     onFavoriteToggle: (Long) -> Unit,
     onClose: () -> Unit,
     onStoreClick: (Int) -> Unit = {}
@@ -771,8 +782,13 @@ fun NearbyStoreBottomSheet(
         )
         Spacer(modifier = Modifier.height(16.dp))
 
+        val titleText = if (searchQuery.isEmpty()) {
+            "주변 매장 ${stores.size}개"
+        } else {
+            "'$searchQuery' 검색 결과 ${stores.size}개"
+        }
         Text(
-            text = "주변 매장 ${stores.size}개",
+            text = titleText,
             fontSize = 18.sp,
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(horizontal = 20.dp)

--- a/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/example/pickitpickit/ui/map/MapViewModel.kt
@@ -139,6 +139,12 @@ class MapViewModel : ViewModel() {
         if (query.isNotBlank()) {
             saveSearchLog(query)
             searchStores(query)
+        } else {
+            val lat = currentLatitude
+            val lng = currentLongitude
+            if (lat != null && lng != null) {
+                loadNearbyStores(lat, lng)
+            }
         }
     }
 
@@ -243,7 +249,7 @@ class MapViewModel : ViewModel() {
     }
 
     fun clearSearch() {
-        _searchQuery.value = ""
+        updateSearchQuery("")
     }
 
     fun showBottomSheet() {


### PR DESCRIPTION
- "내 주변 추천" 버튼 크기 컴팩트화 및 하단 탭바 근접 배치
- 바텀시트 기본 dragHandle 비활성화하여 이중 핸들 노출 이슈 제거 및 패딩 보정
- 검색어 유무에 따라 하단 플로팅 버튼 텍스트("내 주변 추천" vs "검색 결과 보기") 및 바텀시트 타이틀 동적 표기 연동
- 검색창 X 버튼 클릭 및 검색어 초기화 시 내 주변 매장(nearby) 데이터로 실시간 자동 복구 기능 연동